### PR TITLE
Escape `backticks` in GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          head="${{ github.event.pull_request.head.ref }}"
-          title="${{ github.event.pull_request.title }}"
-          body="${{ github.event.pull_request.body }}"
+          head='${{ github.event.pull_request.head.ref }}
+          title='${{ github.event.pull_request.title }}'
+          body='${{ github.event.pull_request.body }}'
           gh pr create --base main --head "$head" --title "$title" --body "$body" --draft


### PR DESCRIPTION
Escape `backticks` in the GitHub Actions workflow to ensure proper handling of pull request attributes.