### PR TITLE
Fix syntax error in PR automation workflow (escape `backticks`)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          head='${{ github.event.pull_request.head.ref }}
+          head='${{ github.event.pull_request.head.ref }}'
           title='${{ github.event.pull_request.title }}'
           body='${{ github.event.pull_request.body }}'
           gh pr create --base main --head "$head" --title "$title" --body "$body" --draft


### PR DESCRIPTION
Correct a syntax error in the pull request automation workflow to ensure proper execution.