### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.author_association == 'OWNER'
+    if: github.event.pull_request.base.ref == 'ww/latest' && github.event.pull_request.author_association == 'OWNER'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
- Introduce a workflow to automate merging pull requests into the `ww/latest` branch and create draft pull requests to the `main` branch.
- Removed unsupported julia version 1.11. Add upcoming release versions.
- Add testing on Windows.
- Use default architecture to avoid slow rosetta translation on macOS.
- Use cache action from julia-actions