### PR TITLE
Cache wavenumber and interpolate on demand

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyBalanceModel"
 uuid = "68dbb056-390c-4f33-8773-0304cbd749ae"
-version = "0.2.4-DEV.1" # welding model dev branch
+version = "0.2.4-DEV.4" # welding model dev branch
 authors = ["Waylon Wu <me@waylonwu.net>", "Navid C. Constantinou <navidcy@users.noreply.github.com>"]
 
 [deps]

--- a/src/EnergyBalanceModel.jl
+++ b/src/EnergyBalanceModel.jl
@@ -111,9 +111,7 @@ Solutions{ClassicModel, sin, false} with:
   with forcing Forcing{false}(0.0) (constant forcing)
 ```
 """
-function run_example(
-    model::M=MIZModel(); plotbackend::Symbol=Plot.find_backend()
-)::Solutions{M,sin,false} where M<:AbstractModel
+function run_example(model::M=MIZModel())::Solutions{M,sin,false} where M<:AbstractModel
     st = SpaceTime{sin}(180, 2000, 50)
     forcing = Forcing(0.0)
     par = default_parameters(model)
@@ -134,7 +132,7 @@ function run_example(
         sols = integrate(model, st, forcing, par, init)
     end # if ===; else
     try # plot results
-        fig = plot_raw(sols, plotbackend)
+        fig = plot_raw(sols)
         display(fig)
     catch err
         if err isa Plot.BackendError
@@ -153,39 +151,30 @@ import PrecompileTools as PT
 
 PT.@setup_workload begin
     import InteractiveUtils as IU
-    ms = Tuple(M() for M in IU.subtypes(AbstractModel) if M !== Infrastructure.ModelDiff)
     Fs = (identity, sin)
     fs_args = ((0.0,), (0.0, 1.0, 0.0, (1, 1), (1.0, -1.0)))
-    spectrum = bretschneider(3.0, 9.5)
-    m2s = Dict{AbstractModel,Solutions}()
+    m2s = Dict{Type{<:AbstractModel},Solutions}()
     redirect_stdout(devnull)
     redirect_stderr(devnull)
     PT.@compile_workload begin
-        for m in ms, F in Fs, farg in fs_args
+        for M in (ClassicModel, MIZModel), F in Fs, farg in fs_args
             st = SpaceTime{F}(10, 10, 1)
             forcing = Forcing(farg...)
-            par = default_parameters(m)
+            par = default_parameters(M())
             T = fill(0.0, st.nx)
             init = Collection{Vec}(:Tg => T)
-            if m isa ClassicModel
+            if M === ClassicModel
                 init.E = par.cw * T
-            else # MIZModel or WIModel
+            else # MIZModel
                 init.Ei = zeros(st.nx)
                 init.Ew = par.cw * T
                 init.h = zeros(st.nx)
                 init.D = zeros(st.nx)
             end # if isa; elseif
-            local sol
-            try # avoid AssertionError from WIModel
-                m isa WIModel ?
-                    sol = integrate(m, st, forcing, par, init; spectrum) :
-                    sol = integrate(m, st, forcing, par, init)
-            catch err
-                err isa AssertionError || err isa InexactError || rethrow(err)
-            end # try; catch err
-            F === sin && length(farg) == 1 && (m2s[m] = sol)
+            sol = integrate(M(), st, forcing, par, init)
+            F === sin && length(farg) == 1 && (m2s[M] = sol)
         end # for m, F, farg
-        m2s[MIZModel()] - m2s[ClassicModel()]
+        m2s[MIZModel] - m2s[ClassicModel]
     end # PT.@compile_workload begin
 end # PT.@setup_workload begin
 

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -2,7 +2,7 @@ module Infrastructure # EnergyBalanceModel.
 
 using ..Utilities
 
-import Integrals as Intgr, InteractiveUtils as IU, SparseArrays as SA, Statistics as Stats
+import Integrals as Intgr, InteractiveUtils as IU, SparseArrays as SA, Statistics as Stats, StyledStrings as SS
 
 export AbstractModel, ClassicModel, MIZModel, WIModel, ModelDiff
 export Collection, Forcing, Par, Solutions, SpaceTime, Vec, AbstractSpectrum
@@ -825,7 +825,12 @@ function integrate(
     lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::AbstractSpectrum
 ) # -> Solutions{WIModel,F,C}
     # initialise
+    println(SS.styled"{warning:Caching wavenumber...}")
+    startat = time()
     vars, sols, annusol = initialise(model, st, forcing, par, init; lastonly, spectrum)
+    took = time() - startat
+    print("\033[A\033[2K")
+    println(SS.styled"{success:Wavenumber cached} in $(round(took; digits=2)) s\n")
     if isfinite(updatefreq)
         progress::Progress = Progress(
             length(st.T), "Integrating WIModel", updatefreq;

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -825,12 +825,20 @@ function integrate(
     lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::AbstractSpectrum
 ) # -> Solutions{WIModel,F,C}
     # initialise
-    println(SS.styled"{warning:Caching wavenumber...}")
-    startat = time()
-    vars, sols, annusol = initialise(model, st, forcing, par, init; lastonly, spectrum)
-    took = time() - startat
-    print("\033[A\033[2K")
-    println(SS.styled"{success:Wavenumber cached} in $(round(took; digits=2)) s\n")
+    print(SS.styled"{warning:Caching wavenumber...}", lpad("", 10))
+    start = time()
+    task = Threads.@spawn initialise(model, st, forcing, par, init; lastonly, spectrum)
+    timer = Timer(
+        _ -> print("\e[10D", lpad(string(round(time()-start; digits=1)), 8), " s"),
+        0.1; interval=0.1
+    )
+    vars, sols, annusol = fetch(task)
+    close(timer)
+    println(
+        "\r\e[2K",
+        SS.styled"{success:Wavenumber cached}",
+        " in ", round(time()-start; digits=2), " s\n"
+    )
     if isfinite(updatefreq)
         progress::Progress = Progress(
             length(st.T), "Integrating WIModel", updatefreq;

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -38,7 +38,6 @@ Base.getindex(layout::Layout, inx...) = (var=layout.vars[inx...], title=layout.t
 
 struct BackendError <: Exception
     requested::Symbol
-    loaded::Symbol
 end # struct BackendError
 
 function Base.showerror(io::IO, err::BackendError)::Nothing
@@ -49,11 +48,6 @@ function Base.showerror(io::IO, err::BackendError)::Nothing
             io,
             "Backend package $(err.requested) is not loaded or unsupported. Try `import $(err.requested)` first."
         )
-        err.loaded === :missing ||
-            println(
-                io,
-                "Hint: Another backend package $(err.loaded) is already loaded."
-            )
     end # if ===; else
     return nothing
 end # function Base.showerror
@@ -107,14 +101,7 @@ end # function default_layout
 
 isloaded(::Val)::Bool = false
 
-function find_backend()::Symbol
-    for backend in (:GLMakie, :CairoMakie, :WGLMakie)
-        isloaded(Val(backend)) && return backend
-    end # for backend
-    return :missing
-end # function find_backend
-
-init_backend(::Val{S}) where S = throw(BackendError(S, find_backend()))
+init_backend(::Val{S}) where S = throw(BackendError(S))
 
 """
     backend() -> Union{Module,Missing}
@@ -232,12 +219,11 @@ function limit_size(
 end # function limit_size
 
 """
-    plot_raw(sols::Solutions, into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(), bcknd::Symbol=...; kwargs...) -> Makie.Figure
+    plot_raw(sols::Solutions, into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(); kwargs...) -> Makie.Figure
 
 Plot the the solution variables for each time step in `sols.raw` into the specified Makie
-figure or grid position using the specified Makie backend `bcknd`. If `into` is not
-specified, a new figure will be created. The function will find available backend if not
-specified.
+figure or grid position. If `into` is not specified, a new figure will be created. The
+function will find available backend if not specified.
 
 # Keyword Arguments
 - `layout::Layout{Symbol}`: Layout structure specifying which variables to plot and their
@@ -254,7 +240,6 @@ specified.
 function plot_raw(
     sols::Solutions{M},
     into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(),
-    bcknd::Symbol=find_backend();
     layout::Layout{Symbol}=default_layout(M()),
     inspect::Bool=false,
     xsizelim::Int=1000,
@@ -262,7 +247,6 @@ function plot_raw(
     xrange::NTuple{2,Real}=extrema(sols.spacetime.x),
     trange::NTuple{2,Real}=extrema(sols.ts)
 ) where M<:AbstractModel # -> Union{Mk.Figure,Mk.GridPosition}
-    backend(bcknd)
     xinx, tinx = limit_size(sols.spacetime.x, sols.ts, xsizelim, tsizelim, xrange, trange)
     datatitle = Layout(Matrix{Matrix{Float64}}(undef, size(layout)), layout.titles)
     @simd for linx in eachindex(layout)
@@ -275,12 +259,11 @@ function plot_raw(
 end # function plot_raw
 
 """
-    plot_avg(sols::Solutions, into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(), bcknd::Symbol=...; kwargs...) -> Makie.Figure
+    plot_avg(sols::Solutions, into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(); kwargs...) -> Makie.Figure
 
 Plot the annual average of solution variables in `sols.annual.avg` into the specified Makie
-figure or grid position using the specified Makie backend `bcknd`. If `into` is not
-specified, a new figure will be created. The function will find available backend if not
-specified.
+figure or grid position. If `into` is not specified, a new figure will be created. The
+function will find available backend if not specified.
 
 # Keyword Arguments
 - `layout::Layout{Symbol}`: Layout structure specifying which variables to plot and their
@@ -297,7 +280,6 @@ specified.
 function plot_avg(
     sols::Solutions{M},
     into::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(),
-    bcknd::Symbol=find_backend();
     layout::Layout{Symbol}=default_layout(M()),
     inspect::Bool=false,
     xsizelim::Int=1000,
@@ -305,7 +287,6 @@ function plot_avg(
     xrange::NTuple{2,Real}=extrema(sols.spacetime.x),
     trange::NTuple{2,Real}=(1, sols.spacetime.dur),
 ) where M<:AbstractModel # -> Union{Mk.Figure,Mk.GridPosition}
-    backend(bcknd)
     xinx, tinx = limit_size(sols.spacetime.x, collect(1:sols.spacetime.dur), xsizelim, tsizelim, xrange, trange)
     datatitle = Layout(Matrix{Matrix{Float64}}(undef, size(layout)), layout.titles)
     @simd for linx in eachindex(layout)
@@ -318,7 +299,7 @@ function plot_avg(
 end # function plot_avg
 
 """
-    plot_seasonal(sols::Solutions, fig::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(), bcknd::Symbol=...; kwargs...) -> Makie.Figure
+    plot_seasonal(sols::Solutions, fig::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(); kwargs...) -> Makie.Figure
 
 Using the data from `sols.annual`, plot lines spanned by (`xfunc(sols, year)`,
 `yfunc(sols, season, year)`) for each year and for the seasons `:avg`, `:winter`, and
@@ -344,7 +325,6 @@ annual average are thick solid.
 function plot_seasonal(
     sols::Solutions{<:AbstractModel,F,true},
     fig::Union{Mk.Figure,Mk.GridPosition}=Mk.Figure(),
-    bcknd::Symbol=find_backend();
     xfunc::Function=((sols, year) -> hemispheric_mean(sols.annual.avg.T[year], sols.spacetime.x)),
     yfunc::Function=ice_area,
     title::AbstractString="Ice covered area",
@@ -352,7 +332,6 @@ function plot_seasonal(
     ylabel::AbstractString=Mk.L"A_i",
     inspect::Bool=false
 ) where F # -> Union{Mk.Figure,Mk.GridPosition}
-    backend(bcknd)
     xdata = xfunc.(Ref(sols), 1:sols.spacetime.dur)
     ax = Mk.Axis(fig[1,1]; title, xlabel, ylabel)
     groups = (
@@ -387,7 +366,7 @@ end # function plot_seasonal
 
 import PrecompileTools as PT
 
-function precompile(bcnd::Module)::Nothing
+function precompile(bcknd::Module)::Nothing
     PT.@setup_workload begin
         ints = collect(1:10)
         floats = collect(0.1:0.1:1.0)
@@ -395,7 +374,7 @@ function precompile(bcnd::Module)::Nothing
         layout = Layout(
             reshape([rand(10, 10)], 1, 1), reshape(AbstractString[Mk.L"title"], 1, 1)
         )
-        bcnd.activate!()
+        bcknd.activate!()
         PT.@compile_workload begin
             for t in (ints, floats)
                 contourf_tiles(t, x, layout, Mk.Figure(); inspect=true)

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -56,7 +56,7 @@ function get_cache(
     freqs::AbstractVector, h::T, gamma::T, abstol::T, par::Collection{T}
 )::WavenumberCache{T} where T <: AbstractFloat
     index = iszero(gamma) ? 1 : 2
-    cache = _wavenumber_ice_cache_ref[][index]
+    cache = _wavenumber_ice_cache_ref[][index]::WavenumberCache{T}
     if hash((T, freqs, gamma, abstol, par)) != cache.key || h > cache.hmax + 1
         @warn "Wavenumber cache miss. Recomputing."
         cache = cache_wavenumber!(freqs, par, 1//10^4, max(10, h+1); abstol)[index]
@@ -120,7 +120,7 @@ function cache_wavenumber!(
             hash((T, freqs, par.Gamma, abstol, par)), T(dh), T(hmax),
             wavenumber_ice.(freqs, hvec', Ref(par), par.Gamma; abstol))
     )
-    @eval const _wavenumber_ice_cache_ref = Ref($tup)
+    _wavenumber_ice_cache_ref[] = tup
     return tup
 end # function cache_wavenumber
 

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -23,10 +23,7 @@ Spectrum(freq::Vec, density::Vec) = length(freq) == length(density) ?
     throw(ArgumentError("Frequency and density vectors must be of the same length."))
 
 struct WavenumberCache{T<:AbstractFloat}
-    gamma::T
-    abstol::T
-    par_hash::UInt
-    freqs::Vector{T}
+    key::UInt # hash of (T, freqs, Gamma, abstal, par)
     dh::T
     hmax::T
     wavenumber::Matrix{Complex{T}} # freqs × hs
@@ -55,19 +52,14 @@ function dispersion_relation(
     return lhs - rhs
 end # function dispersion_relation
 
-function get_cache(freqs::AbstractVector, h::T, gamma::T, abstol::T, par::Collection{T})::WavenumberCache{T} where T <: AbstractFloat
+function get_cache(
+    freqs::AbstractVector, h::T, gamma::T, abstol::T, par::Collection{T}
+)::WavenumberCache{T} where T <: AbstractFloat
     index = iszero(gamma) ? 1 : 2
     cache = _wavenumber_ice_cache_ref[][index]
-    if (
-        !(cache isa WavenumberCache{T}) ||
-        cache.abstol != abstol ||
-        cache.gamma != gamma ||
-        cache.par_hash != hash(par) ||
-        cache.freqs != freqs ||
-        h > cache.hmax + 1
-    )
+    if hash((T, freqs, gamma, abstol, par)) != cache.key || h > cache.hmax + 1
         @warn "Wavenumber cache miss. Recomputing."
-        cache = cache_wavenumber(freqs, par, 1//10^4, max(10, h+1); abstol)[index]
+        cache = cache_wavenumber!(freqs, par, 1//10^4, max(10, h+1); abstol)[index]
     end # if ||
     return cache
 end # function get_cache
@@ -76,8 +68,8 @@ function interpolate_wavenumber(h::AbstractFloat, cache::WavenumberCache) # -> U
     h > cache.hmax && ArgumentError("h is out of bounds for wavenumber cache.")
     col = floor(Int, h / cache.dh) + 1
     weight = h % cache.dh / cache.dh
-    interp = @. weight * cache.wavenumber[:,col]
-    interp .+= @. (1-weight) * cache.wavenumber[:,col+1]
+    interp = weight * cache.wavenumber[:,col]
+    @. interp += (1-weight) * cache.wavenumber[:,col+1]
     return interp
 end # function interpolate_wavenumber
 
@@ -115,13 +107,18 @@ function wavenumber_ice(
         wavenumber_ice.(omegas, h, Ref(par), gamma; abstol)
 end # function wavenumber_ice
 
-function cache_wavenumber(
+function cache_wavenumber!(
     freqs::AbstractVector, par::Collection{T}, dh::Real, hmax::Real; abstol::T=T(1e-10)
 )::NTuple{2,WavenumberCache{T}} where T <: AbstractFloat
     hvec = Vector{T}(0:dh:hmax)
     tup = (
-        WavenumberCache(zero(T), abstol, hash(par), freqs, T(dh), T(hmax), wavenumber_ice.(freqs, hvec', Ref(par), zero(T); abstol)),
-        WavenumberCache(par.Gamma, abstol, hash(par), freqs, T(dh), T(hmax), wavenumber_ice.(freqs, hvec', Ref(par), par.Gamma; abstol))
+        WavenumberCache(
+            hash((T, freqs, zero(T), abstol, par)), T(dh), T(hmax),
+            wavenumber_ice.(freqs, hvec', Ref(par), zero(T); abstol)
+        ),
+        WavenumberCache(
+            hash((T, freqs, par.Gamma, abstol, par)), T(dh), T(hmax),
+            wavenumber_ice.(freqs, hvec', Ref(par), par.Gamma; abstol))
     )
     @eval const _wavenumber_ice_cache_ref = Ref($tup)
     return tup
@@ -217,7 +214,7 @@ function Infrastructure.initialise(
     annusol.spectrum_ref[] = deepcopy(spectrum)
     vars.Ewave = zeros(st.nx)
     vars.lambda = Vec(undef, st.nx)
-    cache_wavenumber(spectrum.freq, par, 1//10^4, 10)
+    cache_wavenumber!(spectrum.freq, par, 1//10^4, 10)
     return (vars, sols, annusol)
 end # function Infrastructure.initialise
 

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -5,6 +5,7 @@ using ..Infrastructure, ..Utilities
 
 import EnergyBalanceModel.MIZEBM
 
+import InteractiveUtils as IU
 import Integrals as Intgr
 import NonlinearSolve as NlinSol
 
@@ -20,6 +21,18 @@ end # struct Spectrum
 Spectrum(freq::Vec, density::Vec) = length(freq) == length(density) ?
     Spectrum(freq, 2pi ./ freq, density) :
     throw(ArgumentError("Frequency and density vectors must be of the same length."))
+
+struct WavenumberCache{T<:AbstractFloat}
+    gamma::T
+    abstol::T
+    par_hash::UInt
+    freqs::Vector{T}
+    dh::T
+    hmax::T
+    wavenumber::Matrix{Complex{T}} # freqs × hs
+end
+
+const _wavenumber_ice_cache_ref = Ref{NTuple{2,WavenumberCache}}()
 
 function bretschneider(
     Hs::Float64, Tp::Float64, freq::Vec=collect(range(2pi/23.8, 2pi/2.5; step=7.5e-2))
@@ -42,23 +55,49 @@ function dispersion_relation(
     return lhs - rhs
 end # function dispersion_relation
 
+function get_cache(freqs::AbstractVector, h::T, gamma::T, abstol::T, par::Collection{T})::WavenumberCache{T} where T <: AbstractFloat
+    index = iszero(gamma) ? 1 : 2
+    cache = _wavenumber_ice_cache_ref[][index]
+    if (
+        !(cache isa WavenumberCache{T}) ||
+        cache.abstol != abstol ||
+        cache.gamma != gamma ||
+        cache.par_hash != hash(par) ||
+        cache.freqs != freqs ||
+        h > cache.hmax + 1
+    )
+        @warn "Wavenumber cache miss. Recomputing."
+        cache = cache_wavenumber(freqs, par, 1//10^4, max(10, h+1); abstol)[index]
+    end # if ||
+    return cache
+end # function get_cache
+
+function interpolate_wavenumber(h::AbstractFloat, cache::WavenumberCache) # -> Union{Nothing,Vector{Complex}}
+    h > cache.hmax && ArgumentError("h is out of bounds for wavenumber cache.")
+    col = floor(Int, h / cache.dh) + 1
+    weight = h % cache.dh / cache.dh
+    interp = @. weight * cache.wavenumber[:,col]
+    interp .+= @. (1-weight) * cache.wavenumber[:,col+1]
+    return interp
+end # function interpolate_wavenumber
+
 function wavenumber_ice(
     omega::Float64, h::Float64, par::Par, gamma::Float64=0.0;
-    init::ComplexF64=omega^2/par.g + 0im, abstol::Float64=1e-10
+    abstol::Float64=1e-10, # init::ComplexF64=omega^2/par.g + 0im
 )::ComplexF64
     prob = NlinSol.NonlinearProblem{false}(
-        (k, _) -> dispersion_relation(k, omega, gamma, h, par), init
+        (k, _) -> dispersion_relation(k, omega, gamma, h, par), omega^2/par.g + 0im
     )
     sol = NlinSol.solve(
         prob, NlinSol.NewtonRaphson(; autodiff=NlinSol.AutoFiniteDiff()); abstol
     )
-    (real(sol.u) < 0 || imag(sol.u) < 0 || abs(sol.resid) > 1) && abs(init) < 100  &&
-        return wavenumber_ice(omega, h, par, gamma; init=10init) # try another initial guess
+    # (real(sol.u) < 0 || imag(sol.u) < 0 || abs(sol.resid) > 1) && abs(init) < 100  &&
+    #     return wavenumber_ice(omega, h, par, gamma; init=10init) # try another initial guess
     stalledsol = sol.retcode === NlinSol.ReturnCode.Stalled && abs(sol.resid) < 10abstol
-    NlinSol.SciMLBase.successful_retcode(sol) || stalledsol ||
+    NlinSol.SciMLBase.successful_retcode(sol) || # stalledsol ||
         @warn(
             "Nonlinear solver did not converge when solving for wavenumber. Result may be inaccurate.",
-            sol.retcode, sol.resid
+            sol.retcode, sol.resid, sol.u, omega, h
         )
     @isdebugging() && stalledsol && (
         isdefined(@__MODULE__, :_stalled_kice_sols) ?
@@ -67,9 +106,30 @@ function wavenumber_ice(
     return sol.u
 end # function wavenumber_ice
 
-function moment(S::Spectrum, n::Int; coeff::Function=one)::Float64
+function wavenumber_ice(
+    omegas::AbstractVector, h::T, par::Collection{T}, gamma::T=zero(T); abstol::T=T(1e-10)
+)::Vector{Complex{T}} where T <: AbstractFloat
+    cache = get_cache(omegas, h, gamma, abstol, par)
+    return h < cache.hmax ?
+        interpolate_wavenumber(h, cache) :
+        wavenumber_ice.(omegas, h, Ref(par), gamma; abstol)
+end # function wavenumber_ice
+
+function cache_wavenumber(
+    freqs::AbstractVector, par::Collection{T}, dh::Real, hmax::Real; abstol::T=T(1e-10)
+)::NTuple{2,WavenumberCache{T}} where T <: AbstractFloat
+    hvec = Vector{T}(0:dh:hmax)
+    tup = (
+        WavenumberCache(zero(T), abstol, hash(par), freqs, T(dh), T(hmax), wavenumber_ice.(freqs, hvec', Ref(par), zero(T); abstol)),
+        WavenumberCache(par.Gamma, abstol, hash(par), freqs, T(dh), T(hmax), wavenumber_ice.(freqs, hvec', Ref(par), par.Gamma; abstol))
+    )
+    @eval const _wavenumber_ice_cache_ref = Ref($tup)
+    return tup
+end # function cache_wavenumber
+
+function moment(S::Spectrum, n::Int; coeff::Vector=ones(length(S.freq)))::Float64
     int = Intgr.solve(
-        Intgr.SampledIntegralProblem(@.(coeff(S.freq) * S.freq^n * S.density), S.freq),
+        Intgr.SampledIntegralProblem(@.(coeff * S.freq^n * S.density), S.freq),
         Intgr.SimpsonsRule()
     )
     Intgr.SciMLBase.successful_retcode(int) ||
@@ -80,19 +140,13 @@ end # function moment
 moment_elevation(S::Spectrum, n::Int)::Float64 = moment(S, n)
 
 moment_strain(S::Spectrum, n::Int, h::Float64, par::Par)::Float64 = moment(
-    S, n; coeff=(freq -> real(wavenumber_ice(freq, h, par, 0.0))^4 * h^2/4)
+    S, n; coeff=real.(wavenumber_ice(S.freq, h, par, 0.0)).^4 * h^2/4
 )
 
-@persistent(
-    alpha1::Vector{Float64}, input::UInt=0x0,
-    function attenuate(S::Spectrum, L::Float64, h::Float64, phi::Float64, par::Par)::Spectrum
-        if input != hash((S.freq, h, par))
-            alpha1 = imag.(wavenumber_ice.(S.freq, h, Ref(par), par.Gamma))
-            input = hash((S.freq, h, par))
-        end # if !=
-        return Spectrum(S.freq, S.period, @. S.density * exp(-2phi*alpha1 * L))
-    end # function attenuate
-) # @persistent
+function attenuate(S::Spectrum, L::Float64, h::Float64, phi::Float64, par::Par)::Spectrum
+    alpha1 = imag.(wavenumber_ice(S.freq, h, par, par.Gamma))
+    return Spectrum(S.freq, S.period, @. S.density * exp(-2phi*alpha1 * L))
+end # function attenuate) # @persistent
 
 wave_period(S::Spectrum)::Float64 = 2pi * sqrt(moment_elevation(S, 0) / moment_elevation(S, 2))
 
@@ -163,6 +217,7 @@ function Infrastructure.initialise(
     annusol.spectrum_ref[] = deepcopy(spectrum)
     vars.Ewave = zeros(st.nx)
     vars.lambda = Vec(undef, st.nx)
+    cache_wavenumber(spectrum.freq, par, 1//10^4, 10)
     return (vars, sols, annusol)
 end # function Infrastructure.initialise
 


### PR DESCRIPTION
- Cache wavenumber grids per spectrum/params and interpolate by thickness during WIM runs.
- Precompute the cache on WIM initialization with a timing message.
- Simplify plotting backend handling and precompile workload.