### PR TITLE
Add EBMProblem and solve problem API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyBalanceModel"
 uuid = "68dbb056-390c-4f33-8773-0304cbd749ae"
-version = "0.2.4-DEV.6" # welding model dev branch
+version = "0.2.7-DEV.0" # ww/problem_api
 authors = ["Waylon Wu <me@waylonwu.net>", "Navid C. Constantinou <navidcy@users.noreply.github.com>"]
 
 [deps]

--- a/src/EnergyBalanceModel.jl
+++ b/src/EnergyBalanceModel.jl
@@ -5,50 +5,52 @@ A comprehensive package for solving a classic Energy Balance Model (EBM) (Wagner
 Eisenman, 2015) and an extended EBM with the inclusion of a Marginal Ice Zone (MIZ). Other
 utilities for data handling and visualization are also provided.
 
-To get started, define a space-time domain, a forcing function, parameters, and initial
-conditions. Then call `integrate` to run the model. See documentation of `SpaceTime`,
-`Forcing`, `default_parameters`, `Collection`, and `integrate` for details. The following
-example runs the EBM with MIZ for 50 years on a 180-point latitudinal grid equally spaced in
-latitude, with 2000 timesteps per year and a constant forcing of 0.0. The initial conditions
-are uniform temperature of 17°C with no ice. The results are saved and plotted.
+To get started, choose a model (`ClassicModel`, `MIZModel`, or `WIModel`) and bundle it with
+its inputs into an `EBMProblem`. Every input is optional and defaults to a sensible value,
+so `EBMProblem(model)` already gives a fully-specified, runnable problem; override the
+space-time domain, forcing, parameters, initial conditions, or wave spectrum through the
+keyword arguments when needed. Then call `solve` to run it. See the documentation of
+`EBMProblem`, `solve`, `SpaceTime`, `Forcing`, `default_parameters`, and `Collection` for
+details.
+
+The following example runs the wave-influenced EBM (`WIModel`) with all defaults: 50 years
+on a 180-point latitudinal grid equally spaced in latitude, 2000 timesteps per year, a
+constant forcing of 0.0, initial conditions of uniform temperature 17°C with no ice, and a
+default Bretschneider incident wave spectrum. The results are saved and plotted.
 
 ```julia-repl
 julia> using EnergyBalanceModel
 
-julia> st = SpaceTime{sin}(180, 2000, 50);
+julia> problem = EBMProblem(WIModel())
+EBMProblem{Float64} with:
+  model:      WIModel
+  spacetime:  SpaceTime{sin}(180, 2000, 50)
+  forcing:    Forcing(0.0) (constant forcing)
+  parameters: 32 entries
+  initconds:  5 variables: Set([:Tg, :Ei, :D, :h, :Ew])
+  spectrum:   Spectrum(30 components)
 
-julia> forcing = Forcing(0.0);
+julia> sols = solve(problem)
+Wavenumber cached in 7.29 s
 
-julia> par = default_parameters(MIZModel());
-
-julia> T = fill(17.0, st.nx);
-
-julia> init = Collection{Vec}(
-           :Ei => zeros(st.nx),
-           :Ew => T .* par.cw,
-           :h => zeros(st.nx),
-           :D => zeros(st.nx),
-           :Tg => T,
-       );
-
-julia> sols = integrate(MIZModel(), st, forcing, par, init)
-Integrating
+Integrating WIModel
  100000/100000 [━━━━━━━━━━━━━━━━━━━━━━━━━━━]  100%
- 1:21/-0:00 1231.41/sec                     Done ✓
+ 0:39/-0:00 2575.71/sec                     Done ✓
  t = 50.0
-Solutions{EnergyBalanceModel.Infrastructure.MIZModel, sin, false} with:
-  10 solution variables: Set([:T, :Ei, :Ti, :D, :n, :h, :phi, :Ew, :E, :Tw])
+Solutions{WIModel, sin, false} with:
+  12 solution variables: Set([:Ti, :n, :D, :h, :lambda, :phi, :Ew, :E, :Tw, :T, :Ei, :Ewave])
   on 180 latitudinal gridboxes: [0.00436331, 0.0130896 … 2, 0.999914, 0.99999]
   and 2000 timesteps: 49.00025:0.0005:49.99975
-  with forcing Forcing{false}(0.0) (constant forcing)
+  with forcing Forcing(0.0) (constant forcing)
 
 julia> save(sols, "./example.jld2");
 
 julia> import GLMakie; plot_raw(sols)
 ```
 
-You can also run the example above by calling `run_example()`. To run the classic EBM
-instead, call `run_example(ClassicModel())`.
+You can also run a standard example by calling `run_example()`, which uses the `MIZModel` by
+default. To run the wave-influenced or classic EBM instead, call `run_example(WIModel())` or
+`run_example(ClassicModel())`.
 
 See the documentation for `save`, `load`, `plot_raw`, `plot_avg`, and `plot_seasonal` for
 details on data handling and visualisation.
@@ -56,9 +58,9 @@ details on data handling and visualisation.
 module EnergyBalanceModel
 
 export ClassicModel, MIZModel, WIModel
-export Collection, Forcing, Par, Solutions, SpaceTime, Vec
+export Collection, Forcing, Par, Solutions, SpaceTime, EBMProblem
 export Spectrum, bretschneider, monochromatic
-export default_parameters, integrate
+export default_parameters, integrate, solve
 export hemispheric_mean, ice_area
 export Layout, backend, plot_avg, plot_raw, plot_seasonal
 export run_example
@@ -77,8 +79,8 @@ using .ClassicEBM, .Infrastructure, .MIZEBM, .Plot, .Utilities, .WIMEBM
 
 Run a standard example simulation for the specified `model` (either an instance of
 `MIZModel`, `WIModel`, or `ClassicModel`). The results of the last year (year 50) are
-plotted using the specified Makie backend `plotbackend`. The backend package must be loaded beforehand
-(e.g., `import GLMakie`).
+plotted using the specified Makie backend `plotbackend`. The backend package must be loaded
+beforehand (e.g., `import GLMakie`).
 
 The model is run on a 180-point latitudinal grid equally spaced in latitude, with 2000
 timesteps per year for 50 years and a constant forcing of 0.0. The initial conditions are
@@ -112,25 +114,8 @@ Solutions{ClassicModel, sin, false} with:
 ```
 """
 function run_example(model::M=MIZModel())::Solutions{M,sin,false} where M<:AbstractModel
-    st = SpaceTime{sin}(180, 2000, 50)
-    forcing = Forcing(0.0)
-    par = default_parameters(model)
-    T = fill(17.0, st.nx)
-    init = Collection{Vec}(:Tg => T)
-    if M === ClassicModel
-        init.E = par.cw * T
-    else # MIZModel or WIModel
-        init.Ei = zeros(st.nx)
-        init.Ew = par.cw * T
-        init.h = zeros(st.nx)
-        init.D = zeros(st.nx)
-    end # if ===; elseif
-    if M === WIModel
-        spectrum = bretschneider(3.0, 9.5)
-        sols = integrate(model, st, forcing, par, init; spectrum)
-    else # no waves
-        sols = integrate(model, st, forcing, par, init)
-    end # if ===; else
+    problem = EBMProblem(model)
+    sols = solve(problem)
     try # plot results
         fig = plot_raw(sols)
         display(fig)

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -5,12 +5,12 @@ using ..Utilities
 import Integrals as Intgr, InteractiveUtils as IU, SparseArrays as SA, Statistics as Stats, StyledStrings as SS
 
 export AbstractModel, ClassicModel, MIZModel, WIModel, ModelDiff
-export Collection, Forcing, Par, Solutions, SpaceTime, Vec
+export Collection, Forcing, Par, Solutions, SpaceTime, Vec, EBMProblem
 export Spectrum, bretschneider, monochromatic
 export default_parameters, default_parval
 export get_diffop
 export hemispheric_mean, ice_area
-export create_storages, integrate
+export create_storages, integrate, solve
 
 """
     Vec
@@ -653,6 +653,151 @@ for model in IU.subtypes(AbstractModel)
     @eval default_parameters(::$model)::Par = default_parameters($(Symbol(namelower, "_parvars")))
 end # for model
 
+"""
+    EBMProblem(model::AbstractModel, ::Type{FT}=Float64; st, forcing, parameters, initconds, spectrum) -> EBMProblem{FT}
+
+Bundle a `model` together with everything needed to integrate it — the space-time domain,
+the climate forcing, the model parameters, the initial conditions, and (for `WIModel`) the
+incident wave spectrum — into a single `EBMProblem` that can be passed to `solve`.
+
+The floating-point type `FT` (default `Float64`) sets the precision used throughout the
+problem. Every other input is supplied as a keyword argument; each one is optional and falls
+back to a sensible default, so `EBMProblem(model)` produces a fully-specified, runnable
+problem. The keyword arguments are:
+- `st`: the `SpaceTime` domain, or a `NamedTuple` of overrides for its fields `nx`, `nt`,
+  `dur`, and `F` (e.g. `st=(; nx=90, dur=100)`). Defaults to `SpaceTime{sin}(180, 2000,
+  50)`.
+- `forcing`: a `Forcing`, a `Number` (used as a constant forcing), or a `NamedTuple` of the
+  fields accepted by `Forcing`. Defaults to no forcing, `Forcing(0)`.
+- `parameters`: a `Collection` of parameters, or a `NamedTuple` of overrides applied on top
+  of `default_parameters(model)`. Defaults to `default_parameters(model)`.
+- `initconds`: a `Collection` of initial conditions, or a `Vector` giving a starting
+  temperature field `T` (from which the remaining variables are derived). Defaults to a
+  uniform temperature of 17°C with no ice.
+- `spectrum`: a `Spectrum` describing the incident wave field. Only valid for `WIModel`,
+  where it defaults to `bretschneider(3, 9.5)`; supplying it for any other model is an
+  error.
+
+# Examples
+```julia-repl
+julia> EBMProblem(WIModel())
+EBMProblem{Float64} with:
+  model:      WIModel
+  spacetime:  SpaceTime{sin}(180, 2000, 50)
+  forcing:    Forcing(0.0) (constant forcing)
+  parameters: 32 entries
+  initconds:  5 variables: Set([:Tg, :Ei, :D, :h, :Ew])
+  spectrum:   Spectrum(30 components)
+
+julia> EBMProblem(WIModel(); st=(dur=100,))
+EBMProblem{Float64} with:
+  model:      WIModel
+  spacetime:  SpaceTime{sin}(180, 2000, 100)
+  forcing:    Forcing(0.0) (constant forcing)
+  parameters: 32 entries
+  initconds:  5 variables: Set([:Tg, :Ei, :D, :h, :Ew])
+  spectrum:   Spectrum(30 components)
+```
+"""
+mutable struct EBMProblem{T<:AbstractFloat}
+    model::AbstractModel
+    st::SpaceTime
+    forcing::Forcing
+    parameters::Collection{T}
+    initconds::Collection{Vec}
+    spectrum::Union{Spectrum,Nothing}
+
+    function EBMProblem{FT}(
+        model::AbstractModel,
+        st::SpaceTime=SpaceTime{sin}(180, 2000, 50),
+        forcing::Forcing=Forcing(zero(FT)),
+        parameters::Collection{FT}=default_parameters(model),
+        initconds::Union{Collection{Vector{FT}},Nothing}=nothing;
+        spectrum::Union{Spectrum,Nothing}=nothing
+    ) where FT<:AbstractFloat
+        if isnothing(initconds)
+            T = fill(FT(17), st.nx)
+            initconds = Collection{Vector{FT}}(
+                :Ei => zeros(FT, st.nx),
+                :Ew => T .* parameters.cw,
+                :h => zeros(FT, st.nx),
+                :D => zeros(FT, st.nx),
+                :Tg => T,
+            ) # Collection{Vector{FT}}
+        end
+        model isa WIModel || isnothing(spectrum) ||
+            throw(ArgumentError("Spectrum should only be provided for WIModel."))
+        model isa WIModel && isnothing(spectrum) &&
+            (spectrum = bretschneider(FT(3), FT(9.5)))
+        return new{FT}(model, st, forcing, parameters, initconds, spectrum)
+    end # function EBMProblem{FT}
+end # mutable struct EBMProblem
+
+function EBMProblem(
+    model::AbstractModel, ::Type{FT}=Float64;
+    st::Union{SpaceTime,NamedTuple}=(; ),
+    forcing::Union{Forcing,Number,NamedTuple}=0,
+    parameters::Union{Collection{FT},NamedTuple}=(; ),
+    initconds::Union{Collection{Vector{FT}},Vector{FT},Nothing}=nothing,
+    spectrum::Union{Spectrum,Nothing}=nothing
+)::EBMProblem{FT} where FT<:AbstractFloat
+    if !(st isa SpaceTime)
+        nx = get(st, :nx, 180)
+        st_inst = SpaceTime{get(st, :F, sin)}(nx, get(st, :nt, 2000), get(st, :dur, 50))
+    else # st isa SpaceTime
+        nx = st.nx
+        st_inst = st
+    end # if !, else
+    if forcing isa Forcing
+        forcing_inst = forcing
+    else # forcing isa Number or NamedTuple
+        forcing_inst =
+            forcing isa Number ?
+                Forcing(FT(forcing)) :
+                Forcing(forcing.base, forcing.peak, forcing.cool, forcing.holdyrs, forcing.rates)
+    end # if isa, else
+    if parameters isa Collection
+        parameters_inst = parameters
+    else # parameters isa NamedTuple
+        parameters_inst = default_parameters(model)
+        foreach(k -> (parameters_inst[k] = parameters[k]), propertynames(parameters))
+    end # if isa, else
+    if initconds isa Collection
+        initconds_inst = initconds
+    elseif initconds isa Vector
+        initconds_inst = Collection{Vector{FT}}(
+            :Ei => zeros(FT, nx), :Ew => initconds .* parameters_inst.cw,
+            :h => zeros(FT, nx), :D => zeros(FT, nx), :Tg => initconds,
+        )
+    else # initconds isa nothing
+        T = fill(FT(17), nx)
+        initconds_inst = Collection{Vector{FT}}(
+            :Ei => zeros(FT, nx), :Ew => T .* parameters_inst.cw,
+            :h => zeros(FT, nx), :D => zeros(FT, nx), :Tg => T,
+        )
+    end # if isa, elseif, else
+    return EBMProblem{FT}(model, st_inst, forcing_inst, parameters_inst, initconds_inst; spectrum)
+end # function EBMProblem
+
+Base.show(io::IO, prob::EBMProblem)::Nothing = print(
+    io, typeof(prob), '(', typeof(prob.model), ", ", prob.st, ", ", repr(prob.forcing), ')'
+)
+
+function Base.show(io::IO, ::MIME"text/plain", prob::EBMProblem)::Nothing
+    println(io, typeof(prob), " with:")
+    println(io, "  model:      ", typeof(prob.model))
+    println(io, "  spacetime:  ", prob.st)
+    println(io, "  forcing:    ", repr(prob.forcing))
+    println(io, "  parameters: ", length(prob.parameters), " entries")
+    println(io, "  initconds:  ", length(prob.initconds), " variables: ", propertynames(prob.initconds))
+    if !isnothing(prob.spectrum)
+        print(io, "  spectrum:   ", prob.spectrum)
+    else
+        print(io, "  spectrum:   nothing")
+    end # if !isnothing
+    return nothing
+end # function Base.show
+
 # calculate diffusion operator matrix
 @persistent(
     diffop::SA.SparseMatrixCSC{Float64,Int64} = SA.spzeros(Float64, 0, 0),
@@ -928,5 +1073,45 @@ function integrate(
     end # for ti
     return sols
 end # function integrate
+
+"""
+    solve(prob::EBMProblem; lastonly::Bool=true, updatefreq::Float64=1.0) -> Solutions{M,F,C}
+
+Integrate the `EBMProblem` `prob` and return the results in a `Solutions` object. This is
+the high-level entry point that dispatches to the appropriate `integrate` method for the
+problem's model, forwarding the spectrum automatically when the model is a `WIModel`.
+
+When `lastonly=true`, only the last year of the solution is stored for each timestep,
+otherwise the full solution is stored. A progress bar is displayed and updated with
+frequency `updatefreq`. If `updatefreq` is `Inf`, no progress bar is shown.
+
+# Examples
+```julia-repl
+julia> problem = EBMProblem(WIModel());
+
+julia> sols = solve(problem)
+Wavenumber cached in 7.29 s
+
+Integrating WIModel
+ 100000/100000 [━━━━━━━━━━━━━━━━━━━━━━━━━━━]  100%
+ 0:39/-0:00 2575.71/sec                     Done ✓
+ t = 50.0
+Solutions{WIModel, sin, false} with:
+  12 solution variables: Set([:Ti, :n, :D, :h, :lambda, :phi, :Ew, :E, :Tw, :T, :Ei, :Ewave])
+  on 180 latitudinal gridboxes: [0.00436331, 0.0130896 … 2, 0.999914, 0.99999]
+  and 2000 timesteps: 49.00025:0.0005:49.99975
+  with forcing Forcing(0.0) (constant forcing)
+```
+"""
+solve(prob::EBMProblem; lastonly::Bool=true, updatefreq::Float64=1.0) =
+    prob.model isa WIModel ?
+        integrate(
+            prob.model, prob.st, prob.forcing, prob.parameters, prob.initconds;
+            lastonly, updatefreq, spectrum=prob.spectrum
+        ) :
+        integrate(
+            prob.model, prob.st, prob.forcing, prob.parameters, prob.initconds;
+            lastonly, updatefreq
+        )
 
 end # module Infrastructure

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -5,7 +5,8 @@ using ..Utilities
 import Integrals as Intgr, InteractiveUtils as IU, SparseArrays as SA, Statistics as Stats, StyledStrings as SS
 
 export AbstractModel, ClassicModel, MIZModel, WIModel, ModelDiff
-export Collection, Forcing, Par, Solutions, SpaceTime, Vec, AbstractSpectrum
+export Collection, Forcing, Par, Solutions, SpaceTime, Vec
+export Spectrum, bretschneider, monochromatic
 export default_parameters, default_parval
 export get_diffop
 export hemispheric_mean, ice_area
@@ -354,7 +355,97 @@ function (forcing::Forcing{false})(T::Float64)::Float64 # varying forcing
 end # function (forcing::Forcing{false})
 
 # Spectrum for WIM
-abstract type AbstractSpectrum end
+"""
+    Spectrum(freq::Vec, density::Vec)
+
+Represents a wave energy spectrum for the wave-ice interaction model ([`WIModel`](@ref)).
+
+The angular frequencies `freq` (rad s⁻¹) and the corresponding spectral energy `density`
+must be vectors of the same length. The wave periods are computed as `2π ./ freq` and stored
+in the `period` field.
+
+# Fields
+- `freq::Vec`: angular frequencies (rad s⁻¹)
+- `period::Vec`: wave periods (s), derived as `2π ./ freq`
+- `density::Vec`: spectral energy density at each frequency
+
+See also [`bretschneider`](@ref) and [`monochromatic`](@ref) for convenience constructors.
+
+# Examples
+```julia-repl
+julia> Spectrum([0.5, 1.0, 1.5], [0.2, 0.5, 0.1])
+Spectrum([0.5, 1.0, 1.5], [12.566370614359172, 6.283185307179586, 4.1887902047863905], [0.2, 0.5, 0.1])
+```
+"""
+struct Spectrum
+    freq::Vec
+    period::Vec
+    density::Vec
+end # struct Spectrum
+
+Spectrum(freq::Vec, density::Vec) = length(freq) == length(density) ?
+    Spectrum(freq, 2pi ./ freq, density) :
+    throw(ArgumentError("Frequency and density vectors must be of the same length."))
+
+Base.show(io::IO, S::Spectrum)::Nothing = print(
+    io, "Spectrum(", length(S.freq), " components)"
+)
+
+function Base.show(io::IO, ::MIME"text/plain", S::Spectrum)::Nothing
+    println(io, "Spectrum with ", length(S.freq), " frequency components:")
+    println(io, "  ω ∈ [", round(minimum(S.freq); digits=3), ", ", round(maximum(S.freq); digits=3), "] rad s⁻¹")
+    println(io, "  T ∈ [", round(minimum(S.period); digits=2), ", ", round(maximum(S.period); digits=2), "] s")
+    print(io, "  peak density at T = ", round(S.period[argmax(S.density)]; digits=2), " s")
+    return nothing
+end # function Base.show
+
+"""
+    bretschneider(Hs::Float64, Tp::Float64, freq::Vec=collect(range(2π/23.8, 2π/2.5; step=7.5e-2))) -> Spectrum
+
+Construct a Bretschneider wave [`Spectrum`](@ref) with significant wave height `Hs` (m) and
+peak period `Tp` (s), evaluated at the angular frequencies `freq` (rad s⁻¹).
+
+The spectral energy density is given by
+``S(T) = \\frac{1.25 H_s^2 T^5}{8\\pi T_p^4} \\exp\\!\\left[-1.25 (T/T_p)^4\\right]``,
+where ``T = 2\\pi / \\omega`` is the wave period.
+
+# Examples
+```julia-repl
+julia> S = bretschneider(3.0, 9.5);
+
+julia> length(S.freq)
+14
+```
+"""
+function bretschneider(
+    Hs::Float64, Tp::Float64, freq::Vec=collect(range(2pi/23.8, 2pi/2.5; step=7.5e-2))
+)::Spectrum
+    T = 2pi ./ freq
+    return Spectrum(freq, @. 1.25 * Hs^2 * T^5 / (8pi * Tp^4) * exp(-1.25(T/Tp)^4))
+end # function bretschneider
+
+"""
+    monochromatic(Hs::Float64, Tp::Float64, freq::Vec=collect(range(2π/(Tp+0.1), 2π/(Tp-0.1); step=1e-3)); eps::Float64=1e-6) -> Spectrum
+
+Construct an approximately monochromatic wave [`Spectrum`](@ref) with significant wave
+height `Hs` (m) and peak period `Tp` (s).
+
+The energy is concentrated near the peak angular frequency ``2\\pi / T_p`` using a narrow
+Gaussian of variance `eps`, so that the total energy matches that of a monochromatic wave of
+height `Hs`. Smaller `eps` produces a sharper peak.
+
+# Examples
+```julia-repl
+julia> S = monochromatic(3.0, 9.5);
+
+julia> isapprox(S.freq[argmax(S.density)], 2pi / 9.5; atol=1e-3)
+true
+```
+"""
+monochromatic(
+    Hs::Float64, Tp::Float64, freq::Vec=collect(range(2pi/(Tp+0.1), 2pi/(Tp-0.1); step=1e-3));
+    eps::Float64=1e-6
+)::Spectrum = Spectrum(freq, @. Hs^2 / 16 * exp(-(freq - 2pi/Tp)^2 / 2eps) / sqrt(2pi * eps))
 
 """
     Solutions{M,F,V}
@@ -392,7 +483,7 @@ struct Solutions{M<:AbstractModel,F,V}
     annual::@NamedTuple{
         winter::Collection{Vector{Vec}}, summer::Collection{Vector{Vec}}, avg::Collection{Vector{Vec}}
     } # seasonal peak and annual avg
-    spectrum_ref::Ref{AbstractSpectrum} # spectrum used for WIModel, if applicable
+    spectrum_ref::Ref{Spectrum} # spectrum used for WIModel, if applicable
 
     function Solutions{M}(
         st::SpaceTime{F}, forcing::Forcing{V}, par::Par, init::Collection{Vec},
@@ -424,7 +515,7 @@ struct Solutions{M<:AbstractModel,F,V}
                 summer=deepcopy(seasonaltemp),
                 avg=deepcopy(seasonaltemp)
             ), # ( # seasonal
-            Ref{AbstractSpectrum}() # spectrum_ref
+            Ref{Spectrum}() # spectrum_ref
         ) # new
     end # function Solutions
 end # struct Solutions{M,F,V}
@@ -477,7 +568,7 @@ function Base.show(io::IO, ::MIME"text/plain", sols::Solutions)::Nothing
     return nothing
 end # function Base.show
 
-get_spectrum(sol::Solutions{WIModel}) = sol.spectrum_ref[] # -> Spectrum
+get_spectrum(sol::Solutions{WIModel})::Spectrum = sol.spectrum_ref[] # -> Spectrum
 
 # default parameter values
 const default_parval = Par(
@@ -801,7 +892,7 @@ end # function integrate
 
 function integrate(
     model::WIModel, st::SpaceTime, forcing::Forcing, par::Par, init::Collection{Vec};
-    lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::AbstractSpectrum
+    lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::Spectrum
 ) # -> Solutions{WIModel,F,C}
     # initialise
     if isfinite(updatefreq)

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -75,6 +75,9 @@ julia> parameters.D
 julia> getproperty(parameters, :A)
 193.0
 
+julia> parameters[:A]
+193.0
+
 julia> parameters.F = 0.0; parameters.F
 0.0
 ```
@@ -87,6 +90,9 @@ end # struct Collection
 Base.getproperty(coll::Collection, key::Symbol) = getindex(getfield(coll, :dict), key) # -> V
 Base.setproperty!(coll::Collection, key::Symbol, val) = setindex!(getfield(coll, :dict), val, key) # -> Dict{Symbol,V}
 Base.propertynames(coll::Collection)::Set{Symbol} = Set(keys(getfield(coll, :dict)))
+Base.getindex(coll::Collection, key::Symbol) = getproperty(coll, key) # -> V
+Base.setindex!(coll::Collection, val, key::Symbol) = setproperty!(coll, key, val) # -> Dict{Symbol,V}
+Base.keys(coll::Collection)::Set{Symbol} = propertynames(coll)
 Base.iterate(coll::Collection) = iterate(getfield(coll, :dict)) # -> Tuple{Pair{Symbol,V},Int} or Nothing
 Base.iterate(coll::Collection, state::Int) = iterate(getfield(coll, :dict), state) # -> Tuple{Pair{Symbol,V},Int} or Nothing
 Base.length(coll::Collection)::Int = length(getfield(coll, :dict))
@@ -96,7 +102,7 @@ function uniqueunion(ca::Collection{A}, cb::Collection{B}) where {A, B}
     vtype = typejoin(A, B)
     vtype === Any && (vtype = Union{A, B})
     overlap = intersect(propertynames(ca), propertynames(cb))
-    return all(key -> getproperty(ca, key) === getproperty(cb, key), overlap) ?
+    return all(key -> ca[key] === cb[key], overlap) ?
         Collection{vtype}() : Collection{vtype}(union(ca, cb))
 end # function uniqueunion
 
@@ -401,10 +407,10 @@ struct Solutions{M<:AbstractModel,F,V}
         end # if lastonly, else
         # construct raw solution storage
         solraw = Collection{Vector{Vec}}()
-        foreach(var -> setproperty!(solraw, var, Vector{Vec}(undef, length(ts))), vars)
+        foreach(var -> (solraw[var] = Vector{Vec}(undef, length(ts))), vars)
         # construct seasonal solution storage template
         seasonaltemp = Collection{Vector{Vec}}()
-        foreach(var -> setproperty!(seasonaltemp, var, Vector{Vec}(undef, st.dur)), vars)
+        foreach(var -> (seasonaltemp[var] = Vector{Vec}(undef, st.dur)), vars)
         return new{M,F,V}(
             st, # spacetime
             ts,
@@ -443,18 +449,9 @@ function Base.:-(
     diffsol = Solutions{ModelDiff{X,Y}}(st, forcing, par, init, vars, lastonly)
     xinx = findall(in(diffsol.ts), sx.ts)
     yinx = findall(in(diffsol.ts), sy.ts)
-    foreach(
-        var -> setproperty!(
-            diffsol.raw, var,
-            getproperty(sx.raw, var)[xinx] .- getproperty(sy.raw, var)[yinx]
-        ),
-        vars
-    ) # foreach
+    foreach(var -> (diffsol.raw[var] = sx.raw[var][xinx] .- sy.raw[var][yinx]), vars)
     for season in 1:3, var in vars
-        setproperty!(
-            diffsol.annual[season], var,
-            getproperty(sx.annual[season], var)[1:st.dur] .- getproperty(sy.annual[season], var)[1:st.dur]
-        )
+        diffsol.annual[season][var] = sx.annual[season][var][1:st.dur] .- sy.annual[season][var][1:st.dur]
     end # for season, var
     return diffsol
 end # function Base.:-
@@ -620,14 +617,14 @@ function annual_mean(annusol::Solutions)::Collection{Vec}
     # calculate annual mean for each variable except temperatures
     means = Collection{Vec}()
     for var in propertynames(annusol.raw)
-        vecvec = getproperty(annusol.raw, var)
+        vecvec = annusol.raw[var]
         @boundscheck length(vecvec) == annusol.spacetime.nt ||
             throw(
                 ArgumentError(
                     "Length of raw solution vector for $var does not match the number of timesteps per year, when calculating annual mean."
                 )
             ) # throw
-        setproperty!(means, var, crossmean(vecvec))
+        means[var] = crossmean(vecvec)
     end # for var
     return means
 end # function annual_mean
@@ -656,39 +653,21 @@ function savesol!(
     year = ceil(Int, sols.spacetime.T[tinx])
     ti = mod1(tinx, sols.spacetime.nt) # index of time in the year
     # save raw data to annual
-    foreach(
-        var -> getproperty(annusol.raw, var)[ti] = getproperty(varscp, var), # !
-        propertynames(annusol.raw)
-    )
+    foreach(var -> annusol.raw[var][ti] = varscp[var], propertynames(annusol.raw))
     # save raw data
     if !sols.lastonly # save all raw data
-        foreach(
-            var -> setindex!(getproperty(sols.raw, var), getproperty(varscp, var), tinx),
-            propertynames(sols.raw)
-        )
+        foreach(var -> (sols.raw[var][tinx] = varscp[var]), propertynames(sols.raw))
     elseif tinx > length(sols.spacetime.T) - sols.spacetime.nt # save the raw data of the last year
-        foreach(
-            var -> setindex!(getproperty(sols.raw, var), getproperty(varscp, var), ti),
-            propertynames(sols.raw)
-        )
+        foreach(var -> (sols.raw[var][ti] = varscp[var]), propertynames(sols.raw))
     end # if !, elseif
     # save seasonal data
     if ti == sols.spacetime.winter.inx
-        foreach(
-            var -> setindex!(getproperty(sols.annual.winter, var), getproperty(varscp, var), year),
-            propertynames(sols.annual.winter)
-        )
+        foreach(var -> (sols.annual.winter[var][year] = varscp[var]), propertynames(sols.annual.winter))
     elseif ti == sols.spacetime.summer.inx
-        foreach(
-            var -> setindex!(getproperty(sols.annual.summer, var), getproperty(varscp, var), year),
-            propertynames(sols.annual.summer)
-        )
+        foreach(var -> (sols.annual.summer[var][year] = varscp[var]), propertynames(sols.annual.summer))
     elseif ti == sols.spacetime.nt # calculate annual average
         means = annual_mean(annusol)
-        foreach(
-            var -> setindex!(getproperty(sols.annual.avg, var), getproperty(means, var), year),
-            propertynames(sols.annual.avg)
-        )
+        foreach(var -> (sols.annual.avg[var][year] = means[var]), propertynames(sols.annual.avg))
     end # if ==, elseif*2
     return sols
 end # function savesol!

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -250,7 +250,7 @@ function plot_raw(
     xinx, tinx = limit_size(sols.spacetime.x, sols.ts, xsizelim, tsizelim, xrange, trange)
     datatitle = Layout(Matrix{Matrix{Float64}}(undef, size(layout)), layout.titles)
     @simd for linx in eachindex(layout)
-        datatitle.vars[linx] = matricify(getindex.(getproperty(sols.raw, layout[linx].var)[tinx], Ref(xinx)))
+        datatitle.vars[linx] = matricify(getindex.(sols.raw[layout[linx].var][tinx], Ref(xinx)))
     end # for inx
     return contourf_tiles(
         sols.ts[tinx], sols.spacetime.x[xinx], datatitle, into;
@@ -290,7 +290,7 @@ function plot_avg(
     xinx, tinx = limit_size(sols.spacetime.x, collect(1:sols.spacetime.dur), xsizelim, tsizelim, xrange, trange)
     datatitle = Layout(Matrix{Matrix{Float64}}(undef, size(layout)), layout.titles)
     @simd for linx in eachindex(layout)
-        datatitle.vars[linx] = matricify(getindex.(getproperty(sols.annual.avg, layout[linx].var)[tinx], Ref(xinx)))
+        datatitle.vars[linx] = matricify(getindex.(sols.annual.avg[layout[linx].var][tinx], Ref(xinx)))
     end # for inx
     return contourf_tiles(
         collect(tinx), sols.spacetime.x[xinx], datatitle, into;

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -8,53 +8,6 @@ import InteractiveUtils as IU
 import Integrals as Intgr
 import NonlinearSolve as NlinSol
 
-export Spectrum
-export bretschneider, monochromatic
-
-"""
-    Spectrum(freq::Vec, density::Vec)
-
-Represents a wave energy spectrum for the wave-ice interaction model ([`WIModel`](@ref)).
-
-The angular frequencies `freq` (rad s⁻¹) and the corresponding spectral energy `density`
-must be vectors of the same length. The wave periods are computed as `2π ./ freq` and stored
-in the `period` field.
-
-# Fields
-- `freq::Vec`: angular frequencies (rad s⁻¹)
-- `period::Vec`: wave periods (s), derived as `2π ./ freq`
-- `density::Vec`: spectral energy density at each frequency
-
-See also [`bretschneider`](@ref) and [`monochromatic`](@ref) for convenience constructors.
-
-# Examples
-```julia-repl
-julia> Spectrum([0.5, 1.0, 1.5], [0.2, 0.5, 0.1])
-Spectrum([0.5, 1.0, 1.5], [12.566370614359172, 6.283185307179586, 4.1887902047863905], [0.2, 0.5, 0.1])
-```
-"""
-struct Spectrum <: AbstractSpectrum
-    freq::Vec
-    period::Vec
-    density::Vec
-end # struct Spectrum
-
-Spectrum(freq::Vec, density::Vec) = length(freq) == length(density) ?
-    Spectrum(freq, 2pi ./ freq, density) :
-    throw(ArgumentError("Frequency and density vectors must be of the same length."))
-
-Base.show(io::IO, S::Spectrum)::Nothing = print(
-    io, "Spectrum(", length(S.freq), " components)"
-)
-
-function Base.show(io::IO, ::MIME"text/plain", S::Spectrum)::Nothing
-    println(io, "Spectrum with ", length(S.freq), " frequency components:")
-    println(io, "  ω ∈ [", round(minimum(S.freq); digits=3), ", ", round(maximum(S.freq); digits=3), "] rad s⁻¹")
-    println(io, "  T ∈ [", round(minimum(S.period); digits=2), ", ", round(maximum(S.period); digits=2), "] s")
-    print(io, "  peak density at T = ", round(S.period[argmax(S.density)]; digits=2), " s")
-    return nothing
-end # function Base.show
-
 struct WavenumberCache{T<:AbstractFloat}
     key::UInt # hash of (T, freqs, Gamma, abstal, par)
     dh::T
@@ -63,54 +16,6 @@ struct WavenumberCache{T<:AbstractFloat}
 end
 
 const _wavenumber_ice_cache_ref = Ref{NTuple{2,WavenumberCache}}()
-
-"""
-    bretschneider(Hs::Float64, Tp::Float64, freq::Vec=collect(range(2π/23.8, 2π/2.5; step=7.5e-2))) -> Spectrum
-
-Construct a Bretschneider wave [`Spectrum`](@ref) with significant wave height `Hs` (m) and
-peak period `Tp` (s), evaluated at the angular frequencies `freq` (rad s⁻¹).
-
-The spectral energy density is given by
-``S(T) = \\frac{1.25 H_s^2 T^5}{8\\pi T_p^4} \\exp\\!\\left[-1.25 (T/T_p)^4\\right]``,
-where ``T = 2\\pi / \\omega`` is the wave period.
-
-# Examples
-```julia-repl
-julia> S = bretschneider(3.0, 9.5);
-
-julia> length(S.freq)
-14
-```
-"""
-function bretschneider(
-    Hs::Float64, Tp::Float64, freq::Vec=collect(range(2pi/23.8, 2pi/2.5; step=7.5e-2))
-)::Spectrum
-    T = 2pi ./ freq
-    return Spectrum(freq, @. 1.25 * Hs^2 * T^5 / (8pi * Tp^4) * exp(-1.25(T/Tp)^4))
-end # function bretschneider
-
-"""
-    monochromatic(Hs::Float64, Tp::Float64, freq::Vec=collect(range(2π/(Tp+0.1), 2π/(Tp-0.1); step=1e-3)); eps::Float64=1e-6) -> Spectrum
-
-Construct an approximately monochromatic wave [`Spectrum`](@ref) with significant wave
-height `Hs` (m) and peak period `Tp` (s).
-
-The energy is concentrated near the peak angular frequency ``2\\pi / T_p`` using a narrow
-Gaussian of variance `eps`, so that the total energy matches that of a monochromatic wave of
-height `Hs`. Smaller `eps` produces a sharper peak.
-
-# Examples
-```julia-repl
-julia> S = monochromatic(3.0, 9.5);
-
-julia> isapprox(S.freq[argmax(S.density)], 2pi / 9.5; atol=1e-3)
-true
-```
-"""
-monochromatic(
-    Hs::Float64, Tp::Float64, freq::Vec=collect(range(2pi/(Tp+0.1), 2pi/(Tp-0.1); step=1e-3));
-    eps::Float64=1e-6
-)::Spectrum = Spectrum(freq, @. Hs^2 / 16 * exp(-(freq - 2pi/Tp)^2 / 2eps) / sqrt(2pi * eps))
 
 function dispersion_relation(
     k::ComplexF64, omega::Float64, gamma::Float64, h::Float64, par::Par

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ forcing = Forcing(0.0)
 
 mizpar = default_parameters(MIZModel())
 T = fill(17.0, st.nx)
-mizinit = Collection{Vec}(
+mizinit = Collection{Vector{Float64}}(
     :Ei => zeros(st.nx),
     :Ew => mizpar.cw * T,
     :h => zeros(st.nx),
@@ -14,7 +14,7 @@ mizinit = Collection{Vec}(
 ) # Collection
 
 clapar = default_parameters(ClassicModel())
-clainit = Collection{Vec}(
+clainit = Collection{Vector{Float64}}(
     :E => clapar.cw * T,
     :Tg => T
 )


### PR DESCRIPTION
Introduces a high-level `EBMProblem` + `solve` API for setting up and running the models, with documentation.

- Add indexing (`coll[:key]`) interface to `Collection` and use it throughout
- Move `Spectrum`/`bretschneider`/`monochromatic` from WIMEBM into Infrastructure
- Add `EBMProblem` and `solve` with docstrings and updated examples