### PR TITLE
Clamp wave-limited floe size inside cell average

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyBalanceModel"
 uuid = "68dbb056-390c-4f33-8773-0304cbd749ae"
-version = "0.2.10-DEV.0" # ww/dmn
+version = "0.2.13-DEV.0" # ww/wimclamp
 authors = ["Waylon Wu <me@waylonwu.net>", "Navid C. Constantinou <navidcy@users.noreply.github.com>"]
 
 [deps]

--- a/src/mizebm.jl
+++ b/src/mizebm.jl
@@ -145,7 +145,6 @@ function _initialise(
 ) # -> Tuple{Collection{Vec}, Solutions{M,F,V}, Solutions{M,F,V}}
     # create storages
     solvars = Set{Symbol}((:Ei, :Ew, :D, :h, :E, :Ti, :Tw, :T, :phi, :n))
-    model isa WIModel && push!(solvars, :Ewave, :lambda) # add wave variables for WIModel
     vars, sols, annusol = create_storages(model, solvars, st, forcing, par, init; lastonly)
     # compute phi and Tw
     vars.nextphi = concentration(vars.Ei, vars.h, par)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -70,18 +70,7 @@ const mizmodel_layout = Layout(
     ]
 )
 
-const wimodel_layout = Layout(
-    [
-        :E   :Ewave  :lambda
-        :Tw  :Ti     :T
-        :h   :D      :phi
-    ],
-    [
-        Mk.L"$E$ ($\mathrm{J\,m^{-2}}$)"                Mk.L"$E_{\mathrm{wave}}$"                       Mk.L"$\lambda$ ($\mathrm{m}$)"
-        Mk.L"$T_{\mathrm{w}}$ ($\mathrm{\degree\!C}$)"  Mk.L"$T_{\mathrm{i}}$ ($\mathrm{\degree\!C}$)"  Mk.L"$T$ ($\mathrm{\degree\!C}$)"
-        Mk.L"$\bar{h}$ ($\mathrm{m}$)"                  Mk.L"$\bar{\mathcal{D}}$ ($\mathrm{m}$)"        Mk.L"$\varphi$"
-    ]
-)
+const wimodel_layout = mizmodel_layout
 
 for model in filter(!=(ModelDiff), IU.subtypes(AbstractModel))
     namelower = lowercase(split(string(model), '.')[end])

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -207,8 +207,6 @@ end # function Infrastructure.initialise
 function Infrastructure.step!(
     ::WIModel, t::Float64, f::Float64, vars::Collection{Vec}, st::SpaceTime, par::Par; spectrum::Spectrum
 )::Collection{Vec}
-    vars.Ewave = zeros(st.nx)
-    vars.lambda = fill(wave_length(spectrum, 0.0, par), st.nx)
     breakup = falses(st.nx) # track which cells are breaking
     edgeinx = findfirst(>(0), vars.h)
     if !isnothing(edgeinx) # if there is any ice
@@ -229,14 +227,6 @@ function Infrastructure.step!(
                 updateD!(frontd, xi, vars, l, L)
                 breakup[xi] = true
             end # if >, else
-            vars.Ewave[xi] = cell_mean(
-                sl -> wave_strain(sl, vars.h[xi], par),
-                spect, vars.phi[xi], alpha1, L
-            )
-            vars.lambda[xi] = cell_mean(
-                sl -> wave_length(sl, vars.h[xi], par),
-                spect, vars.phi[xi], alpha1, L
-            )
             spect = atted_spect # update spectrum
         end # for xi
     end # if !

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -150,6 +150,19 @@ function fracture_distance(S::Spectrum, h::Float64, phi::Float64, L::Float64, pa
     return sol.u
 end # function fracture_distance
 
+function cell_mean(func::Function, spectrum::Spectrum, phi::Real, alpha1::Vector, L::Real) # -> Real
+    sol = Intgr.solve(
+        Intgr.IntegralProblem((l, _) -> func(attenuate(spectrum, l, phi, alpha1)), (0, L)),
+        Intgr.QuadGKJL()
+    )
+    Intgr.SciMLBase.successful_retcode(sol) ||
+        @warn(
+            "Integral did not converge when computing cell mean. Result may be inaccurate.",
+            sol.retcode, sol.resid
+        )
+    return sol.u / L
+end # function cell_mean
+
 flexural_min(h::Real, par::Collection) = # -> Real
     1//2 * (pi^4 * par.Y * h^3 / (48par.rhow * par.g * (1-par.nu^2)))^(1//4)
 
@@ -158,26 +171,12 @@ expectation(dmn::Real, dmx::Real, gamma::Real) = # -> Real
     dmn < dmx ?
         gamma * dmn / (gamma - 1) * (1 - (dmn/dmx)^(gamma-1)) / (1 - (dmn/dmx)^gamma) : dmn
 
-function mean_size(spectrum::Spectrum, L::Real, h::Real, phi::Real, par::Collection) # -> AbstractFloat
-    alpha1 = ice_attenuation(spectrum, h, par)
-    sol = Intgr.solve(
-        Intgr.IntegralProblem(
-            (l, _) -> expectation(
-                flexural_min(h, par),
-                1/2 * wave_length(attenuate(spectrum, l, phi, alpha1), h, par), # dmx
-                par.gamma
-            ),
-            (0, L)
-        ),
-        Intgr.QuadGKJL()
-    )
-    Intgr.SciMLBase.successful_retcode(sol) ||
-        @warn(
-            "Integral did not converge when computing mean size. Result may be inaccurate.",
-            sol.retcode, sol.resid
-        )
-    return sol.u / L
-end # function mean_size
+mean_size(
+    spectrum::Spectrum, h::Real, phi::Real, L::Real, alpha1::Vector, par::Collection, Dbar::Real
+) = cell_mean(
+    sl -> min(expectation(flexural_min(h, par), 1/2 * wave_length(sl, h, par), par.gamma), Dbar),
+    spectrum, phi, alpha1, L
+)
 
 # Physical grid length at a given index in metres
 function grid_length(st::SpaceTime{F}, i::Int)::Float64 where F
@@ -191,11 +190,8 @@ function grid_length(st::SpaceTime{F}, i::Int)::Float64 where F
     return dtheta / (pi/2) * 1e7
 end # function grid_length
 
-function updateD!(newD::Float64, xi::Int, vars::Collection{Vec}, l::Float64=1.0, L::Float64=1.0)::Nothing
-    dbar = (l*newD + (L-l)*vars.D[xi]) / L # weighted average based on fracture distance
-    dbar < vars.D[xi] && (vars.D[xi] = dbar) # update floe size if it has been reduced by breaking # !
-    return nothing
-end # function updateD!
+updateD!(newD::Float64, xi::Int, vars::Collection{Vec}, l::Float64=1.0, L::Float64=1.0) = # -> Number
+    vars.D[xi] = (l*newD + (L-l)*vars.D[xi]) / L # weighted average based on fracture distance
 
 function Infrastructure.initialise(
     model::WIModel, st::SpaceTime, forcing::Forcing, par::Par, init::Collection{Vec};
@@ -220,21 +216,28 @@ function Infrastructure.step!(
         spect = spectrum
         for xi in edgeinx:st.nx
             L = grid_length(st, xi)
-            atted_spect = attenuate(spect, L, vars.h[xi], vars.phi[xi], par)
+            alpha1 = ice_attenuation(spect, vars.h[xi], par)
+            atted_spect = attenuate(spect, L, vars.phi[xi], alpha1)
             atted_strain = wave_strain(atted_spect, vars.h[xi], par)
             if atted_strain > par.Ec # full breakup
-                dbar = mean_size(spect, L, vars.h[xi], vars.phi[xi], par)
+                dbar = mean_size(spect, vars.h[xi], vars.phi[xi], L, alpha1, par, vars.D[xi])
                 updateD!(dbar, xi, vars)
                 breakup[xi] = true
             elseif wave_strain(spect, vars.h[xi], par) > par.Ec # partial breakup
                 l = fracture_distance(spect, vars.h[xi], vars.phi[xi], L, par)
-                frontd = mean_size(spect, l, vars.h[xi], vars.phi[xi], par)
+                frontd = mean_size(spect, vars.h[xi], vars.phi[xi], l, alpha1, par, vars.D[xi])
                 updateD!(frontd, xi, vars, l, L)
                 breakup[xi] = true
             end # if >, else
+            vars.Ewave[xi] = cell_mean(
+                sl -> wave_strain(sl, vars.h[xi], par),
+                spect, vars.phi[xi], alpha1, L
+            )
+            vars.lambda[xi] = cell_mean(
+                sl -> wave_length(sl, vars.h[xi], par),
+                spect, vars.phi[xi], alpha1, L
+            )
             spect = atted_spect # update spectrum
-            vars.Ewave[xi] = wave_strain(atted_spect, vars.h[xi], par)
-            vars.lambda[xi] = wave_length(atted_spect, vars.h[xi], par)
         end # for xi
     end # if !
     Infrastructure.step!(MIZModel(), t, f, vars, st, par; breakup) # thermodynamics

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,5 @@ end # @testset begin
         (Float64, spectrum.freq, wimpar.Gamma, 1e-10, wimpar)
     )
     @test wimsols.spectrum_ref[].density == spectrum.density
-    @test hasproperty(wimsols.raw, :Ewave) && hasproperty(wimsols.raw, :lambda)
-    # @test lastyear_hemi_mean(wimsols, :T) - lastyear_hemi_mean(mizsols, :T) < 1.0
+    @test lastyear_hemi_mean(wimsols, :T) - lastyear_hemi_mean(mizsols, :T) < 1.0
 end


### PR DESCRIPTION
Clamp the wave-limited floe size inside the cell average so breakup cannot increase the current mean floe size. Reuse per-cell attenuation for mean floe size, wave strain, and wavelength.