### PR TITLE
Add significant wave height Hs diagnostic to WIModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyBalanceModel"
 uuid = "68dbb056-390c-4f33-8773-0304cbd749ae"
-version = "0.2.15-DEV.2" # ww/activeset
+version = "0.2.17-DEV.0" # ww/hsinsols
 authors = ["Waylon Wu <me@waylonwu.net>", "Navid C. Constantinou <navidcy@users.noreply.github.com>"]
 
 [deps]

--- a/src/mizebm.jl
+++ b/src/mizebm.jl
@@ -276,6 +276,7 @@ function _initialise(
 ) # -> Tuple{Collection{Vec}, Solutions{M,F,V}, Solutions{M,F,V}}
     # create storages
     solvars = Set{Symbol}((:Ei, :Ew, :D, :h, :E, :Ti, :Tw, :T, :phi, :n))
+    model isa WIModel && push!(solvars, :Hs) # add wave height for WIModel
     vars, sols, annusol = create_storages(model, solvars, st, forcing, par, init; solver, lastonly)
     # diagnostic variables read by the first step!, on the same timestep as Ei, Ew, h and D
     vars.phi = concentration(vars.Ei, vars.h, par)

--- a/src/wimebm.jl
+++ b/src/wimebm.jl
@@ -207,6 +207,7 @@ function Infrastructure.step!(
     solver::AbstractSolver, spectrum::Spectrum
 )::Collection{Vec}
     breakup = falses(st.nx) # track which cells are breaking
+    vars.Hs = fill(wave_height(spectrum), st.nx) # !
     edgeinx = findfirst(>(0), vars.h)
     if !isnothing(edgeinx) # if there is any ice
         # attenuate spectrum
@@ -214,6 +215,7 @@ function Infrastructure.step!(
         for xi in edgeinx:st.nx
             L = grid_length(st, xi)
             alpha1 = ice_attenuation(spect, vars.h[xi], par)
+            vars.Hs[xi] = wave_height(attenuate(spect, L/2, vars.phi[xi], alpha1))
             atted_spect = attenuate(spect, L, vars.phi[xi], alpha1)
             atted_strain = wave_strain(atted_spect, vars.h[xi], par)
             if atted_strain > par.Ec # full breakup


### PR DESCRIPTION
Adds `Hs` as a tracked solution variable for WIModel for finding the wave-affected MIZ, computing significant wave height from the wave spectrum at each grid cell (post-attenuation) during `step!` in `wimebm.jl`.

Bumps package version to 0.2.17-DEV.2.