### PR TITLE
Make solvers carry their own numerical settings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyBalanceModel"
 uuid = "68dbb056-390c-4f33-8773-0304cbd749ae"
-version = "0.2.15-DEV.2" # ww/activeset
+version = "0.2.18-DEV.0" # ww/solverparams
 authors = ["Waylon Wu <me@waylonwu.net>", "Navid C. Constantinou <navidcy@users.noreply.github.com>"]
 
 [deps]

--- a/src/classicebm.jl
+++ b/src/classicebm.jl
@@ -116,6 +116,9 @@ function Infrastructure.initialise(
     if solver isa GhostLayerSolver
         par.cg = solver.cg
         par.tau = solver.tau
+    else # not GhostLayerSolver; for compatibility for get_statics
+        par.cg = NaN
+        par.tau = NaN
     end # if isa
     return create_storages(
         model, Set{Symbol}((:E, :T, :h)), st, forcing, par, init; solver, lastonly

--- a/src/classicebm.jl
+++ b/src/classicebm.jl
@@ -109,15 +109,22 @@ function solveT(
     return T
 end # function solveT
 
-Infrastructure.initialise(
+function Infrastructure.initialise(
     model::ClassicModel, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec};
     solver::AbstractSolver, lastonly::Bool, _...
-) = create_storages(model, Set{Symbol}((:E, :T, :h)), st, forcing, par, init; solver, lastonly)
-    # -> Tuple{Collection{Vec},Solutions{ClassicModel,F,V},Solutions{ClassicModel,F,V}}
+) # -> Tuple{Collection{Vec},Solutions{ClassicModel},Solutions{ClassicModel}}
+    if solver isa GhostLayerSolver
+        par.cg = solver.cg
+        par.tau = solver.tau
+    end # if isa
+    return create_storages(
+        model, Set{Symbol}((:E, :T, :h)), st, forcing, par, init; solver, lastonly
+    )
+end # function Infrastructure.initialise
 
 function step_temperature!(
     ::GhostLayerSolver, vars::Collection{<:Vector}, aS::Vector, st::SpaceTime, f::Real,
-    par::Collection, stat::NamedTuple, i::Integer; _...
+    par::Collection, stat::NamedTuple, i::Integer
 ) # -> Tuple{Vector,Vector}
     C = @. aS + stat.cg_tau*vars.Tg - par.A + f
     # surface temperature
@@ -139,13 +146,14 @@ function step_temperature!(
 end # function specialised_step!
 
 function step_temperature!(
-    ::NonlinearSolver, vars::Collection{Vector{FT}}, aS::Vector{FT}, st::SpaceTime, f::FT,
-    par::Collection{FT}, _args...; _...
+    solver::NonlinearSolver, vars::Collection{Vector{FT}}, aS::Vector{FT}, st::SpaceTime,
+    f::FT, par::Collection{FT}, _...
 )::NTuple{2,Vector{FT}} where FT <: AbstractFloat
     vars.T0 = solveT0(
         get(vars, :T0, zeros(FT, st.nx)),
         vars.E, get(vars, :h, @. -vars.E / par.Lf * (vars.E<0)),
-        aS, get_diffop(st), f, par
+        aS, get_diffop(st), f, par;
+        solver.abstol
     ) # solveT0 # !
     vars.T = surface_temperature(vars.E, vars.T0, par) # !
     C = @. aS + par.D * $(get_diffop(st)vars.T) - par.A + f
@@ -154,10 +162,10 @@ function step_temperature!(
 end # function specialised_step!
 
 function step_temperature!(
-    ::ActiveSetSolver, vars::Collection{<:Vector}, aS::Vector, st::SpaceTime, f::Real,
-    par::Collection, _args...; max_iter::Integer=10st.nx
+    solver::ActiveSetSolver, vars::Collection{<:Vector}, aS::Vector, st::SpaceTime, f::Real,
+    par::Collection, _...
 ) # -> Tuple{Vector,Vector}
-    vars.T = solveT(vars, aS, st, par, f; max_iter) # !
+    vars.T = solveT(vars, aS, st, par, f; solver.max_iter) # !
     C = @. aS + par.D * $(get_diffop(st)*vars.T) - par.A + f
     @. vars.E += st.dt * (C - par.B*vars.T + par.Fb) # !
     return (vars.T, vars.E)

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -67,51 +67,82 @@ abstract type AbstractSolver end
 
 """
     GhostLayerSolver <: AbstractSolver
+    GhostLayerSolver(cg::Real=0.098, tau::Real=3e-5)
 
-Singleton type selecting the ghost layer scheme of Wagner & Eisenman (2015), in which
-horizontal diffusion acts on a ghost layer of small heat capacity `cg` that is coupled to
-the surface over the short timescale `tau`. The ghost layer temperature is stepped with an
-implicit Euler step, and the surface temperature follows diagnostically.
+Select the ghost layer scheme of Wagner & Eisenman (2015), in which horizontal diffusion
+acts on a ghost layer of small heat capacity `cg` that is coupled to the surface over the
+short timescale `tau`. The ghost layer temperature is stepped with an implicit Euler step,
+and the surface temperature follows diagnostically.
 
-!!! note
-    This scheme gives a poor approximation for `MIZModel` and `WIModel`. It is recommended
-    to use the `ActiveSetSolver` instead.
+# Fields
+- `cg::Float64`: ghost layer heat capacity (W y m^-2 K^-1)
+- `tau::Float64`: ghost layer coupling timescale (y)
 """
-struct GhostLayerSolver <: AbstractSolver end
+struct GhostLayerSolver <: AbstractSolver
+    cg::Float64 # ghost layer heat capacity(W y m^-2 K^-1)
+    tau::Float64 # ghost layer coupling timescale (y)
+    GhostLayerSolver(cg::Real=0.098, tau::Real=3e-5) = new(cg, tau)
+end # struct GhostLayerSolver
 
 """
     ActiveSetSolver <: AbstractSolver
+    ActiveSetSolver(max_iter::Integer=1000)
 
-Singleton type selecting the active set scheme, which classifies the gridboxes as freezing
-or melting at each timestep and iteratively solves the linear system implied by that
-classification for the surface temperature.
+Select the active set scheme, which classifies the gridboxes as freezing or melting at each
+timestep and iteratively solves the linear system implied by that classification for the
+surface temperature. This is the default scheme used by [`solve`](@ref) and
+[`integrate`](@ref).
+
+# Fields
+- `max_iter::Int`: maximum number of iterations allowed for the active set to converge. If
+    the classification has not settled within `max_iter` iterations, a warning is issued and
+    the last iterate is used.
 """
-struct ActiveSetSolver <: AbstractSolver end
+struct ActiveSetSolver <: AbstractSolver
+    max_iter::Int # maximum number of iterations to converge active set
+    ActiveSetSolver(max_iter::Integer=1000) = new(max_iter)
+end # struct ActiveSetSolver
 
 """
     NonlinearSolver <: AbstractSolver
+    NonlinearSolver(abstol::Real=1e-10)
 
-Singleton type selecting the nonlinear scheme, in which the surface temperature is obtained
-by solving the full nonlinear system at each timestep with a Newton-type iteration.
+Select the nonlinear scheme, in which the surface temperature is obtained by solving the
+full nonlinear system at each timestep with a Newton-type iteration.
+
+# Fields
+- `abstol::Float64`: absolute tolerance on the residual of the nonlinear system. A warning
+    is issued if the iteration terminates without reaching it.
 
 !!! note
     This scheme is computationally expensive and it is recommended to use the
-    `ActiveSetSolver` instead.
+    [`ActiveSetSolver`](@ref) instead.
 """
-struct NonlinearSolver <: AbstractSolver end
+struct NonlinearSolver <: AbstractSolver
+    abstol::Float64 # absolute tolerance for nonlinear solver
+    NonlinearSolver(abstol::Real=1e-10) = new(abstol)
+end # struct NonlinearSolver
 
 """
-    DiffSolver{A<:AbstractSolver, B<:AbstractSolver} <: AbstractSolver
+    DiffSolver <: AbstractSolver
+    DiffSolver(solverA::AbstractSolver, solverB::AbstractSolver)
 
-Singleton type recording that a solution was obtained as the difference (A-B) between a
-solution advanced with solver `A` and one advanced with solver `B`.
+A type recording that a solution was obtained as the difference (A-B) between a solution
+advanced with `solverA` and one advanced with `solverB`.
+
+# Fields
+- `solverA::AbstractSolver`: solver that advanced the solution being subtracted from
+- `solverB::AbstractSolver`: solver that advanced the solution being subtracted
 
 This is a bookkeeping type rather than a scheme. It carries the provenance of the two
-solvers in the `solver` field of the [`Solutions`](@ref), and is never used to advance a
-timestep. It is the solver-level counterpart of [`ModelDiff`](@ref), when two models are
-solved with different solvers.
+solvers, along with their settings, in the `solver` field of the [`Solutions`](@ref), and is
+never used to advance a timestep. It is the solver-level counterpart of [`ModelDiff`](@ref),
+when two models are solved with different solvers.
 """
-struct DiffSolver{A<:AbstractSolver, B<:AbstractSolver} <: AbstractSolver end
+struct DiffSolver <: AbstractSolver
+    solverA::AbstractSolver
+    solverB::AbstractSolver
+end # struct DiffSolver
 
 """
     Collection{V}(args...)
@@ -505,12 +536,14 @@ An object to store model solutions. Type parameter `M` is the model type (`MIZMo
 `V` is `true` for variable forcing.
 
 # Fields
-- `model::M`: model type
 - `spacetime::SpaceTime{F}`: space and time on which solutions are defined
 - `ts::Vec`: time vector for stored solutions
 - `forcing::Forcing{V}`: climate forcing
 - `parameters::Collection`: model parameters
 - `initconds::Collection{Vec}`: initial conditions
+- `solver::AbstractSolver`: the [`AbstractSolver`](@ref) instance that advanced the
+    solution, including its numerical settings; a [`DiffSolver`](@ref) if the solution is a
+    difference between two solutions obtained with different solvers
 - `lastonly::Bool`: whether to store solutions for each time step only for the last year
 - `raw::Collection{Vector{Vec}}`: solutions for each time step
 - `annual::@NamedTuple{winter::..., summer::..., avg::...}`: seasonal peak and annual
@@ -588,7 +621,7 @@ function Base.:-(
     init = uniqueunion(sx.initconds, sy.initconds)
     vars = intersect(propertynames(sx.raw), propertynames(sy.raw))
     lastonly = sx.lastonly || sy.lastonly
-    solver = sx.solver === sy.solver ? sx.solver : DiffSolver{typeof(sx.solver), typeof(sy.solver)}()
+    solver = DiffSolver(sx.solver, sy.solver)
     diffsol = Solutions{ModelDiff{X,Y}}(st, forcing, par, init, vars, lastonly; solver)
     xinx = findall(in(diffsol.ts), sx.ts)
     yinx = findall(in(diffsol.ts), sy.ts)
@@ -642,9 +675,6 @@ const default_parval = Collection{Float64}(
     :Fb => 4.0, # heat flux from ocean below (W m^-2)
     :k => 2.0, # sea ice thermal conductivity (W m^-2 K^-1)
     :Lf => 9.5, # sea ice latent heat of fusion (W y m^-3)
-    # for GhostLayerSolver only
-    :cg => 0.098, # ghost layer heat capacity(W y m^-2 K^-1)
-    :tau => 3e-5, # ghost layer coupling timescale (y)
     # MIZ
     :Tm => 0.0, # mean temperature (C)
     :m1 => 1.6e-6_secyear, # empirical constants of lateral melt (m y^-1 K^-1)
@@ -695,9 +725,8 @@ Get default parameters for a given model.
 # Examples
 ```julia-repl
 julia> default_parameters(ClassicModel())
-Collection{Float64} with 16 entries:
+Collection{Float64} with 13 entries:
   :a2 => 0.1
-  :F  => 0.0
   :A  => 193.0
   :k  => 2.0
   :D  => 0.6
@@ -1072,15 +1101,17 @@ function create_storages(
 end # function create_storages
 
 """
-    integrate(model::Union{MIZModel,ClassicModel}, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec}; solver::AbstractSolver, lastonly::Bool=true, updatefreq::Float64=1.0) -> Solutions{ClassicModel,F,C}
-    integrate(model::WIModel, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec}; solver::AbstractSolver, lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::Spectrum) -> Solutions{M,F,C}
+    integrate(model::Union{MIZModel,ClassicModel}, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec}; solver::AbstractSolver=ActiveSetSolver(), lastonly::Bool=true, updatefreq::Float64=1.0) -> Solutions{ClassicModel,F,C}
+    integrate(model::WIModel, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec}; solver::AbstractSolver=ActiveSetSolver(), lastonly::Bool=true, updatefreq::Float64=1.0, spectrum::Spectrum) -> Solutions{M,F,C}
 
 Integrate the specified model over the given `SpaceTime` with climate `Forcing`, model
 parameters `par`, and initial conditions `init`. Results and inputs are stored in a
 `Solutions` object. Use `default_parameters` to get default model parameters. For
 `MIZModel`, `init` must contain the variables `:Ei`, `:Ew`, `:h`, `:D` and `:Tg`; for
 `ClassicModel`, `init` must contain `:E` and `:Tg`. A keyword argument `spectrum` must be
-specified for `WIModel` to indicate the spectrum of the incident wave field.
+specified for `WIModel` to indicate the spectrum of the incident wave field. The `solver`
+instance selects the scheme used to advance the surface temperature at each timestep and
+holds that scheme's numerical settings; see [`AbstractSolver`](@ref).
 
 When `lastonly=true`, only the last year of the solution is stored for each time step,
 otherwise the full solution is stored. A progress bar is displayed and updated with
@@ -1140,7 +1171,9 @@ Integrate the `EBMProblem` `prob` and return the results in a `Solutions` object
 the high-level entry point to `integrate` from `EBMProblem`. The `solver` selects the scheme
 used to advance the surface temperature at each timestep, defaulting to
 [`ActiveSetSolver`](@ref); see [`GhostLayerSolver`](@ref) and [`NonlinearSolver`](@ref) for
-the alternatives.
+the alternatives. Each solver also carries the numerical settings of its scheme in its
+fields, so pass a configured instance to override them, e.g.
+`solve(prob, ActiveSetSolver(500))`.
 
 When `lastonly=true`, only the last year of the solution is stored for each timestep,
 otherwise the full solution is stored. A progress bar is displayed and updated with

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -1015,8 +1015,8 @@ end # function savesol!
 """
     hemispheric_mean(vec::Vec, x::Vec) -> Float64
 
-Calculate the hemispheric mean value of `vec` defined on grid `x` using the trapezoidal
-rule.
+Calculate the hemispheric mean value of `vec` defined on grid `x = sin(latitude)` by
+discretised integration using the Simpson's rule.
 
 # Examples
 ```julia-repl
@@ -1025,12 +1025,12 @@ julia> x = sin.(range(0, pi/2, 180));
 julia> vec = @. 7.5 + 20(1 - 2x^2);
 
 julia> hemispheric_mean(vec, x)
-14.166324413879554
+14.166666666666657
 ```
 """
-function hemispheric_mean(vec::Vec, x::Vec)::Float64
+function hemispheric_mean(vec::Vector, x::Vector) # -> Number
     int = Intgr.solve(
-        Intgr.SampledIntegralProblem(@.(2vec / (pi * sqrt(1-x^2))), x), Intgr.SimpsonsRule()
+        Intgr.SampledIntegralProblem(vec, x), Intgr.SimpsonsRule()
     )
     if !Intgr.SciMLBase.successful_retcode(int)
         @warn "Integral did not converge when computing hemispheric mean. Result may be inaccurate."
@@ -1042,8 +1042,8 @@ end # function hemispheric_mean
 """
     ice_area(phi::Vec, x::Vec) -> Float64
 
-Calculate the area covered by sea ice from the sea ice concentration `phi` defined on grid
-`x` by discretised integration using the Simpson's rule.
+Calculate the area covered by sea ice, in km², from the sea ice concentration `phi` defined
+on grid `x = sin(latitude)` by discretised integration using the Simpson's rule.
 
 # Examples
 ```julia-repl
@@ -1052,18 +1052,16 @@ julia> x = sin.(range(0, pi/2, 181))[1:end-1]; # avoid the singularity at x=1
 julia> phi = @. 2x - x^2;
 
 julia> ice_area(phi, x)
-1.4075808945373096
+1.7001177979051808e8
 ```
 """
-function ice_area(phi::Vec, x::Vec)::Float64
-    int = Intgr.solve(
-        Intgr.SampledIntegralProblem(@.(pi*x * phi / 2sqrt(1-x^2)), x), Intgr.SimpsonsRule()
-    )
+function ice_area(phi::Vector, x::Vector) # -> Number
+    int = Intgr.solve(Intgr.SampledIntegralProblem(phi, x), Intgr.SimpsonsRule())
     if !Intgr.SciMLBase.successful_retcode(int)
         @warn "Integral did not converge when computing ice area. Result may be inaccurate."
         @isdebugging() && @show int.retcode
     end # if !
-    return int.u
+    return 2pi * 6371^2 * int.u
 end # function ice_area
 
 """
@@ -1081,9 +1079,9 @@ julia> ice_area(sols, :summer, 30)
 0.43981792357403693
 ```
 """
-ice_area(sols::Solutions{ClassicModel}, season::Symbol, year::Int)::Float64 =
+ice_area(sols::Solutions{ClassicModel}, season::Symbol, year::Integer) = # -> Real
     ice_area((getproperty(sols.annual, season).E[year].<0), sols.spacetime.x)
-ice_area(sols::Solutions{MIZModel}, season::Symbol, year::Int)::Float64 =
+ice_area(sols::Solutions{<:Union{MIZModel,WIModel}}, season::Symbol, year::Integer) = # -> Real
     ice_area(getproperty(sols.annual, season).phi[year], sols.spacetime.x)
 
 # stub for functions for each model

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -1119,7 +1119,7 @@ Refer to the documentation of the module `EnergyBalanceModel` for an example.
 """
 function integrate(
     model::M, st::SpaceTime, forcing::Forcing, par::Collection, init::Collection{Vec};
-    lastonly::Bool=true, updatefreq::Float64=1.0, solver::AbstractSolver=ActiveSetSolver(), kwargs...
+    lastonly::Bool=true, updatefreq::Real=1.0, solver::AbstractSolver=ActiveSetSolver(), kwargs...
 ) where M<:Union{ClassicModel,MIZModel,WIModel} # -> Solutions{M,F,C}
     # initialise for WIModel
     spectrum = get(kwargs, :spectrum, nothing)
@@ -1197,7 +1197,7 @@ Solutions{WIModel, sin, false} with:
 """
 solve(
     prob::EBMProblem, solver::AbstractSolver=ActiveSetSolver();
-    lastonly::Bool=true, updatefreq::Float64=1.0
+    lastonly::Bool=true, updatefreq::Real=1.0
 ) = integrate( # -> Solutions
     prob.model, prob.st, prob.forcing, prob.parameters, prob.initconds;
     lastonly, updatefreq, solver, prob.spectrum

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -700,7 +700,7 @@ const default_parval = Collection{Float64}(
 
 # parameters used in each model
 const classicmodel_parvars = Set{Symbol}(
-    (:D, :A, :B, :cw, :S0, :S1, :S2, :a0, :a2, :ai, :Fb, :k, :Lf, :cg, :tau)
+    (:D, :A, :B, :cw, :S0, :S1, :S2, :a0, :a2, :ai, :Fb, :k, :Lf)
 )
 const mizmodel_parvars = push!(
     copy(classicmodel_parvars),

--- a/src/mizebm.jl
+++ b/src/mizebm.jl
@@ -51,7 +51,7 @@ function stepTg!(
 end # function stepTg!
 
 solveT0(
-    solve::GhostLayerSolver, x::Vector, t::Float64, h::Vector, Tg::Vector, Tw::Vector,
+    solver::GhostLayerSolver, x::Vector, t::Float64, h::Vector, Tg::Vector, Tw::Vector,
     phi::Vector, f::Real, par::Collection
 ) = @. ( # -> Vector
     $(solar(x, t, :ice, par)) - par.A + f - (1-phi)Tw * (par.B + solver.cg/solver.tau)

--- a/src/mizebm.jl
+++ b/src/mizebm.jl
@@ -22,24 +22,25 @@ ice_temp(T0::Vector, par::Collection) = min.(T0, par.Tm) # -> Vector
 
 # ghost layer scheme
 function stepTg!(
-    t::Float64, Tg::Vec, h::Vec, T0::Vec, Tw::Vec, phi::Vec, f::Float64, st::SpaceTime, par::Collection
+    t::Real, Tg::Vector, h::Vector, T0::Vector, Tw::Vector, phi::Vector, f::Real,
+    st::SpaceTime, par::Collection, cg::Real, tau::Real
 )::Vec
     frez = @. (T0<par.Tm) & (h>0)
     watr = .~frez
     diagphi = SA.spdiagm(phi)
-    invM = SA.spdiagm(inv.(phi * (par.B + par.cg/par.tau) .+ par.k./h))
+    invM = SA.spdiagm(inv.(phi * (par.B + cg/tau) .+ par.k./h))
     Tg .= (
-            (1+st.dt/par.tau)LA.I
-            - st.dt*par.D/par.cg * get_diffop(st)
-            - (st.dt*par.cg/par.tau^2 * diagphi * invM)SA.spdiagm(frez)
+            (1+st.dt/tau)LA.I
+            - st.dt*par.D/cg * get_diffop(st)
+            - (st.dt*cg/tau^2 * diagphi * invM)SA.spdiagm(frez)
         ) \ (
             Tg
-            + st.dt/par.tau * (
+            + st.dt/tau * (
                 (LA.I-diagphi)Tw
                 + (
                     diagphi * (
                         par.Tm * (par.B*LA.I + par.k*LA.I * SA.spdiagm(inv.(h)))
-                        - (par.B + par.cg/par.tau) * (LA.I-diagphi)SA.spdiagm(Tw)
+                        - (par.B + cg/tau) * (LA.I-diagphi)SA.spdiagm(Tw)
                         + SA.spdiagm(solar(st.x, t, :ice, par)) - par.A*LA.I + f*LA.I
                     ) * invM
                 )frez
@@ -50,12 +51,12 @@ function stepTg!(
 end # function stepTg!
 
 solveT0(
-    ::GhostLayerSolver, x::Vector, t::Float64, h::Vector, Tg::Vector, Tw::Vector,
+    solve::GhostLayerSolver, x::Vector, t::Float64, h::Vector, Tg::Vector, Tw::Vector,
     phi::Vector, f::Real, par::Collection
 ) = @. ( # -> Vector
-    $(solar(x, t, :ice, par)) - par.A + f - (1-phi)Tw * (par.B + par.cg/par.tau)
-    + par.Tm * (par.B + par.k/h) + par.cg/par.tau * Tg
-) / (phi * (par.B + par.cg/par.tau) + par.k/h)
+    $(solar(x, t, :ice, par)) - par.A + f - (1-phi)Tw * (par.B + solver.cg/solver.tau)
+    + par.Tm * (par.B + par.k/h) + solver.cg/solver.tau * Tg
+) / (phi * (par.B + solver.cg/solver.tau) + par.k/h)
 
 # nonlinear scheme
 function T0eq(
@@ -169,11 +170,11 @@ end # function area_lead
 
 # fluxes
 function vert_flux(
-    ::GhostLayerSolver, t::Float64, surface::Symbol, Tbar::Vector, f::Real, st::SpaceTime,
-    par::Collection, Tg::Vector
+    solver::GhostLayerSolver, t::Float64, surface::Symbol, Tbar::Vector, f::Real,
+    st::SpaceTime, par::Collection, Tg::Vector
 ) # -> Vector
     L = @. par.A + par.B * (Tbar - par.Tm) # OLR
-    return solar(st.x, t, surface, par) .- L .+ par.cg/par.tau * (Tg-Tbar) .+ par.Fb .+ f
+    return solar(st.x, t, surface, par) .- L .+ solver.cg/solver.tau * (Tg-Tbar) .+ par.Fb .+ f
 end # function vert_flux
 
 function vert_flux(
@@ -238,9 +239,13 @@ forward_euler(var::Vec, grad::Vec, dt::Float64)::Vec = @. var + grad*dt
 
 function step_temperature!(
     solver::GhostLayerSolver, vars::Collection{<:Vector}, t::Real, st::SpaceTime, f::Real,
-    par::Collection, _args...; initstep::Bool=false, _...
+    par::Collection, _args...; initstep::Bool=false
 ) # -> Vector
-    initstep || (vars.Tg = stepTg!(t, vars.Tg, vars.h, vars.T0, vars.Tw, vars.phi, f, st, par)) # !
+    initstep || (
+        vars.Tg = stepTg!(
+            t, vars.Tg, vars.h, vars.T0, vars.Tw, vars.phi, f, st, par, solver.cg, solver.tau
+        )
+    ) #|| # !
     vars.T0 = solveT0(solver, st.x, t, vars.h, vars.Tg, vars.Tw, vars.phi, f, par) # !
     vars.Ti = ice_temp(vars.T0, par) # !
     vars.T = weighted_avg(replace(vars.Ti, NaN=>0.0), vars.Tw, vars.phi) # !
@@ -253,8 +258,9 @@ function step_temperature!(
 ) # -> Vector
     vars.T0 = solveT0(
         solver, get(vars, :T0, fill(par.Tm, st.nx)),
-        st.x, t, vars.h, vars.Tw, vars.phi, get_diffop(st), f, par
-    )
+        st.x, t, vars.h, vars.Tw, vars.phi, get_diffop(st), f, par;
+        solver.abstol
+    ) # solveT0 # !
     vars.Ti = ice_temp(vars.T0, par) # !
     vars.T = weighted_avg(replace(vars.Ti, NaN=>0.0), vars.Tw, vars.phi) # !
     return vars.T
@@ -262,9 +268,9 @@ end # function step_temperature!
 
 function step_temperature!(
     solver::ActiveSetSolver, vars::Collection{<:Vector}, t::Real, st::SpaceTime, f::Real,
-    par::Collection, Flat::Vector, Fbot::Vector; max_iter::Integer=10st.nx, _...
+    par::Collection, Flat::Vector, Fbot::Vector; _...
 )
-    vars.T0, vars.T = solveT0(solver, t, vars, Flat, Fbot, st, f, par; max_iter) # !
+    vars.T0, vars.T = solveT0(solver, t, vars, Flat, Fbot, st, f, par; solver.max_iter) # !
     vars.Ti = ice_temp(vars.T0, par) # !
     return vars.T
 end # function step_temperature!

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -29,8 +29,8 @@ mutable struct Progress
     updates::Int # number of external updates
 
     function Progress(
-        total::Int,
-        title::String="Progress", freq::Float64=1.0;
+        total::Integer,
+        title::String="Progress", freq::Real=1.0;
         width::Int=50, infofeed::Function=Returns("")
     )
         barwidth = width - (ndigits(total) * 2 + 1) - 2 - 5 - 3 # current/total [=> ] xx.x%


### PR DESCRIPTION
Converts the solver types from singletons into structs that carry the numerical
settings of their scheme, so those settings are configurable at the call site and
recorded with the solution.

- `GhostLayerSolver(cg=0.098, tau=3e-5)`, `ActiveSetSolver(max_iter=1000)` and
  `NonlinearSolver(abstol=1e-10)` now hold their own parameters; `DiffSolver` becomes
  a plain struct holding the two solver instances (with settings) rather than
  encoding them as type parameters.
- `cg` and `tau` are removed from `default_parval` and read from the solver instance;
  `ClassicModel`'s `initialise` copies them into `par` for the ghost layer scheme.
- `max_iter` / `abstol` are no longer per-call keyword arguments of
  `step_temperature!`; they come from the solver, so `solve(prob, ActiveSetSolver(500))`
  is the way to override them. Note `max_iter` default changes from `10st.nx` to `1000`.
- Docstrings for the solver types, `integrate` and `solve` updated accordingly.
